### PR TITLE
Updates to status names 

### DIFF
--- a/content/additional-review.md
+++ b/content/additional-review.md
@@ -24,7 +24,7 @@ If you believe a note rated “helpful” on your Tweet doesn’t add helpful co
 - Twitter does not determine the outcome of reviews. The aim of Birdwatch is to empower people on Twitter to determine what additional context is helpful.
 - If the additional ratings change a note's status such that it is no longer rated "helpful", the note will stop being shown on the Tweet.
 - Most additional ratings will likely come in within 24 hours following an author's request, but status can change at any time as ratings are received.
-- A review of one note does not impact the status of other existing notes or newly written notes on the Tweet. If new notes are added and become currently rated helpful, they may be shown on the Tweet.
+- A review of one note does not impact the status of other existing notes or newly written notes on the Tweet. If new notes are added and earn the status of Helpful, they may be shown on the Tweet.
 - Notes are subject to the Twitter Rules, so if you believe a note violates them, you can report it to Twitter.
 
 ## Request additional review

--- a/content/contributor-scores.md
+++ b/content/contributor-scores.md
@@ -12,9 +12,9 @@ In order to get enough data from new raters to be able to assess how similarly t
 
 ## Author Helpfulness Scores
 
-### Author CRH-vs. CRNH Ratio
+### Author Helpful vs. Not Helpful Ratio
 
-This score is the proportion of notes you’ve written (that have gotten at least 5 ratings) that have been labeled Currently Rated Helpful (CRH), minus 5 times the proportion of notes you wrote that were labeled Currently Rated Not Helpful (CRNH).
+This score is the proportion of notes you’ve written (that have gotten at least 5 ratings) that have reached the status of Helpful ("Currently Rated Helpful", or CRH), minus 5 times the proportion of notes you wrote that reached the status of Not Helpful ("Currently Rated Not Helpful", or CRNH).
 
 Contributors must have a ratio greater than 0.0 to be included in the [second round of note scoring](../ranking-notes/#complete-algorithm-steps) (contributors need to write at least 5 CRH notes for every 1 CRNH note they write in order for their ratings to count); this only filters out a very small percentage of raters. Labels on notes that have been deleted after May 19, 2022 continue to affect this score, so that the score can’t be trivially changed by deleting CRNH notes.
 
@@ -24,7 +24,7 @@ This score is the average score of notes you’ve written (that have gotten at l
 
 ## Rater Helpfulness Score
 
-The Rater Helpfulness Score reflects how similar a contributor’s ratings are to the ratings on notes that were eventually labeled “Currently Rated Helpful” or “Currently Not Rated Helpful” (indicating clear widespread consensus among raters, and not labeled “Needs More Ratings”).
+The Rater Helpfulness Score reflects how similar a contributor’s ratings are to the ratings on notes that eventually reached the status of “Helpful” or "Not Helpful” (indicating clear widespread consensus among raters, and not labeled “Needs More Ratings”).
 
 Only [Valid Ratings](./#valid-ratings) are used in computing rater helpfulness scores. This is done to both reward quick rating, and also to prevent one form of artificially gaming this score (retroactively rating old notes with clear labels).
 
@@ -35,11 +35,11 @@ Rater Helpfulness is not defined until the contributor has made at least one val
 A “valid” rating is a rating that’s eligible to be used in determining rater helpfulness scores. The idea is that to prevent manipulation, only ratings that were made before the rater could’ve possibly known what the final note status label is are eligible. To be specific, valid ratings must be:
 
 - Made within the first 48 hours of the note’s creation (because we publicly release all rating data after 48 hours)
-- A rating on a note that eventually ended up getting a Currently Rated Helpful or Not Helpful note status label, so we can compute whether your rating matched the final note status
+- A rating on a note that eventually ended up getting a Helpful or Not Helpful status, so we can compute whether your rating matched the final note status
 - If the note being rated was created before May 18, 2022:
   - Only the first 5 ratings on the note are valid (since note status labels aren’t computed until the note has at least 5 ratings)
 - If the note being rated was created on or after May 18, 2022:
-  - To be valid, the rating must be made before the time of when the note received its first status besides Needs More Ratings. Or, if the note’s status changed from Currently Rated Helpful to Currently Rated Not Helpful or vice versa, then all ratings will be valid as long as they are made before the timestamp of when that most recent status change occurred.
+  - To be valid, the rating must be made before the time of when the note received its first status besides Needs More Ratings. Or, if the note’s status changed from Helpful to Not Helpful or vice versa, then all ratings will be valid as long as they are made before the timestamp of when that most recent status change occurred.
 
 Ratings have the same impact on the note’s final status label whether they are “valid” or not. Whether a rating is valid is only relevant for the computation of rater helpfulness scores.
 

--- a/content/diversity-of-perspectives.md
+++ b/content/diversity-of-perspectives.md
@@ -12,6 +12,6 @@ Birdwatch assesses "different perspectives" entirely based on how people have ra
 
 This approach has a number of benefits. First, it reflects the reality that people’s views can be nuanced, rather than defined by demographics. Second, in support of Birdwatch’s focus on transparency, it allows people working with [Birdwatch public data](../data) to replicate, analyze and audit how Birdwatch works, as it allows Birdwatch to run entirely on publicly available data.
 
-We are constantly evaluating ways to improve this approach (and [welcome suggestions](../feedback)) This current method has shown promising results in helping find quality notes: in surveys of people on Twitter in the US, the majority of respondents found notes designated 'currently rated helpful' by Birdwatch contributors to be “somewhat” or “extremely” helpful — this includes people from across the political spectrum.
+We are constantly evaluating ways to improve this approach (and [welcome suggestions](../feedback)) This current method has shown promising results in helping find quality notes: in surveys of people on Twitter in the US, the majority of respondents found notes that earned a status of "Helpful" by Birdwatch contributors to be “somewhat” or “extremely” helpful — this includes people from across the political spectrum.
 
 If you're interested in the math and code powering Birdwatch, take a look at our [Note Ranking: Under the Hood](../note-ranking/) section.

--- a/content/notes-on-twitter.md
+++ b/content/notes-on-twitter.md
@@ -35,20 +35,20 @@ Many Tweets are seen by most people who will see them in a matter of hours. Note
 - They’re written **on Tweets that have higher visibility**
 - They **quickly receive enough ratings from other contributors**. As a contributor, you can help make this happen by rating notes on the "Needs your help" timeline on Birdwatch.
 
-If a Tweet has a Birdwatch note deemed **Currently rated helpful** by contributors then the note content will be shown in the card, along with a button to rate the note. If the Tweet has multiple notes with **Currently rated helpful** status, the card will show one note, randomly cycling between them at periodic intervals in order to gather additional rating inputs on each.
+If a Tweet has a Birdwatch note that earned a status of Helpful after being rated by enough contributors then the note content will be shown in the card, along with a button to rate the note. If the Tweet has multiple notes that earned a status of Helpful, the card will show one note, randomly cycling between them at periodic intervals in order to gather additional rating inputs on each.
 
-The one exception to this is if a **Currently rated helpful** note deems the Tweet **Not misleading**. In this case, since the Tweet was considered not misleading, the note will not be shown on the Tweet.
+The one exception to this is if a note with a status of Helpful deems the Tweet **Not misleading**. In this case, since the Tweet was considered not misleading, the note will not be shown on the Tweet.
 
 ### Details about which notes are shown
 
-If a Tweet has a Birdwatch note that is “Currently rated helpful” by contributors then the note will be shown in a card on the Tweet, along with a button to rate the note. If the Tweet has multiple notes with “Currently rated helpful” status, the card randomly cycles between the notes at periodic intervals in order to gather additional rating inputs on each.
+If a Tweet has a Birdwatch note that earned a status of Helpful after being rated by enough contributors then the note will be shown in a card on the Tweet, along with a button to rate the note. If the Tweet has multiple notes with a status of Helpful, the card randomly cycles between the notes at periodic intervals in order to gather additional rating inputs on each.
 
-The one exception to this is if a “Currently rated helpful” note deems the Tweet “Not misleading.” In this case, since the Tweet was considered not misleading, the note will not be shown on the Tweet.
+The one exception to this is if a note with a status of Helpful deems the Tweet “Not misleading.” In this case, since the Tweet was considered not misleading, the note will not be shown on the Tweet.
 
 ### Cards only visible to Birdwatch contributors
 
 {{< figure src="../images/notes-on-twitter-count.png">}}
 
-If a Tweet has notes but none yet have “Currently rated helpful” status, the card will show the number of notes, and allow people to tap to read and rate those notes on the Birdwatch site.
+If a Tweet has notes but none yet have earned a status of Helpful, the card will show the number of notes, and allow people to tap to read and rate those notes on the Birdwatch site.
 
-If all notes on a Tweet have “Currently not rated helpful” status, no card will be shown. Birdwatch contributors will still be able to access these notes via the Birdwatch icon displayed in the Tweet details page.
+If all notes on a Tweet have earned a status of Helpful, no card will be shown. Birdwatch contributors will still be able to access these notes via the Birdwatch icon displayed in the Tweet details page.

--- a/content/ranking-notes.md
+++ b/content/ranking-notes.md
@@ -28,7 +28,7 @@ All Birdwatch notes start out with the Needs More Ratings status until they rece
 
 If a note is deleted, the algorithm will still score it (using all non-deleted ratings of that note) and the note will receive a status if it’s been rated more than 5 times, although since it is deleted it will not be shown on Twitter even if its status is Helpful.
 
-Notes with a Note Helpfulness Score of 0.40 and above earn the status of Helpful. Notes with a Note Helpfulness Score less than -0.05 -0.8 \* abs(noteFactorScore) are assigned Not Helpful, where noteFactorScore is described in [Matrix Factorization](#matrix-factorization). Notes with scores in between remain labeled as Needs more Ratings.
+Notes with a Note Helpfulness Score of 0.40 and above earn the status of Helpful. Notes with a Note Helpfulness Score less than -0.05 -0.8 \* abs(noteFactorScore) are assigned Not Helpful, where noteFactorScore is described in [Matrix Factorization](#matrix-factorization). Notes with scores in between remain with a status of Needs more Ratings.
 
 In addition to Helpful / Not Helpful statuses, labels also show the two most commonly chosen explanation tags which describe the reason the note was rated helpful or unhelpful.
 

--- a/content/ranking-notes.md
+++ b/content/ranking-notes.md
@@ -12,7 +12,7 @@ geekdocToc: 1
 katex: true
 ---
 
-Birdwatch notes are submitted and rated by contributors. Ratings are used to determine note status labels (“Currently Rated Helpful”, “Currently Rated Not Helpful”, or “Needs More Ratings”). Note statuses also determine which notes are displayed on each of the [Birdwatch Site’s timelines](../birdwatch-timelines/), and which notes are displayed as [Birdwatch Cards](../notes-on-twitter/) on Tweets.
+Birdwatch notes are submitted and rated by contributors. Ratings are used to determine note status labels (“Helpful”, “Not Helpful”, or “Needs More Ratings”). Note statuses also determine which notes are displayed on each of the [Birdwatch Site’s timelines](../birdwatch-timelines/), and which notes are displayed as [Birdwatch Cards](../notes-on-twitter/) on Tweets.
 
 Only notes that indicate the Tweet as “potentially misleading” are eligible to be displayed as Birdwatch Cards on Tweets; notes that indicate the Tweet is “not misleading” are not displayed as Birdwatch Cards on Tweets. As of March 9, 2022, we have temporarily paused assigning statuses to notes that indicate the Tweet is “not misleading.” Why? People have been confused about how to rate them. As these notes are effectively making the case that the Tweet does not need a note, raters often rated them as “Unhelpful - Tweet doesn’t need a note” so as to indicate the note should not appear on the Tweet. We are planning an improvement to the rating form to resolve this confusion, and plan to resume assigning statuses to “not misleading” notes once that’s in place.
 
@@ -26,17 +26,17 @@ The sections below describe how notes are assigned statuses, which determines ho
 
 All Birdwatch notes start out with the Needs More Ratings status until they receive at least 5 total ratings. Once a note has received at least 5 ratings, it is assigned a Note Helpfulness Score according to the algorithm described below.
 
-If a note is deleted, the algorithm will still score it (using all non-deleted ratings of that note) and the note will receive a status if it’s been rated more than 5 times, although since it is deleted it will not be shown on Twitter even if its status is Currently Rated Helpful.
+If a note is deleted, the algorithm will still score it (using all non-deleted ratings of that note) and the note will receive a status if it’s been rated more than 5 times, although since it is deleted it will not be shown on Twitter even if its status is Helpful.
 
-Notes with a Note Helpfulness Score of 0.40 and above are assigned Currently Rated Helpful. Notes with a Note Helpfulness Score less than -0.05 -0.8 \* abs(noteFactorScore) are assigned Currently Rated Not Helpful, where noteFactorScore is described in [Matrix Factorization](#matrix-factorization). Notes with scores in between remain labeled as Needs more Ratings.
+Notes with a Note Helpfulness Score of 0.40 and above earn the status of Helpful. Notes with a Note Helpfulness Score less than -0.05 -0.8 \* abs(noteFactorScore) are assigned Not Helpful, where noteFactorScore is described in [Matrix Factorization](#matrix-factorization). Notes with scores in between remain labeled as Needs more Ratings.
 
-In addition to Currently Rated / Not Rated Helpful status, labels also show the two most commonly chosen explanation tags which describe the reason the note was rated helpful/unhelpful.
+In addition to Helpful / Not Helpful statuses, labels also show the two most commonly chosen explanation tags which describe the reason the note was rated helpful or unhelpful.
 
-Notes with the status Needs More Ratings remain sorted by recency (newest first), and notes with a Currently Rated / Not Rated Helpful status are sorted by their Helpfulness Score.
+Notes with the status Needs More Ratings remain sorted by recency (newest first), and notes with a Helpful or Not Helpful status are sorted by their Helpfulness Score.
 
 This ranking mechanism is subject to continuous development and improvement with the aim that Birdwatch consistently identifies notes that are found helpful to people from a wide variety of perspectives.
 
-During the pilot phase, rating statuses are only computed at periodic intervals, so there is a time delay from when a note meets the Currently Rated / Not Rated Helpful criteria and when that designation appears on the Birdwatch site. This delay allows Birdwatch to collect a set of independent ratings from people who haven’t yet been influenced by seeing status annotations on certain notes.
+During the pilot phase, rating statuses are only computed at periodic intervals, so there is a time delay from when a note meets the Helpful / Not Helpful criteria and when that designation appears on the Birdwatch site. This delay allows Birdwatch to collect a set of independent ratings from people who haven’t yet been influenced by seeing status annotations on certain notes.
 
 ## Helpful Rating Mapping
 
@@ -72,7 +72,7 @@ Where lambda_i (0.03), the regularization on the intercept terms, is currently 5
 
 The resulting scores that we use for each note are the note intercept terms i_n. These scores on our current data give an approximately Normal distribution, where notes with the highest and lowest intercepts tend to have factors closer to zero.
 
-We currently set the thresholds to achieve a “Currently Rated Helpful” label at 0.40, including less than 10% of the notes, and our threshold to achieve a “Currently Rated Not Helpful” label at –0.08. However, these are far from set in stone and the way we generate status labels from note scores will evolve over time.
+We currently set the thresholds to achieve a “Helpful” label at 0.40, including less than 10% of the notes, and our threshold to achieve a “Not Helpful” label at –0.08. However, these are far from set in stone and the way we generate status labels from note scores will evolve over time.
 
 This approach has a few nice properties:
 
@@ -85,9 +85,9 @@ Note: for now, to avoid overfitting on our very small dataset, we only use 1-dim
 
 ### Determining Note Status Explanation Tags
 
-When notes are labeled with a status (either Currently Rated Helpful or Currently Rated Not Helpful), we display the top two explanation tags that were given by raters to explain why they rated the note helpful or not.
+When notes are labeled with a status (either Helpful or Not Helpful), we display the top two explanation tags that were given by raters to explain why they rated the note helpful or not.
 
-This is done by simply counting the number of times each explanation tag was given filtered to explanation tags that match the final note status label (e.g., if the note status is Currently Rated Helpful we only count helpful explanation tags). Importantly, each explanation tag must be used by at least two different raters. If there aren’t two different tags that are each used by two different raters, then the note’s status label is reverted back to “Needs More Ratings” (this is very rare).
+This is done by simply counting the number of times each explanation tag was given filtered to explanation tags that match the final note status label (e.g., if the note status is Helpful we only count helpful explanation tags). Importantly, each explanation tag must be used by at least two different raters. If there aren’t two different tags that are each used by two different raters, then the note’s status label is reverted back to “Needs More Ratings” (this is very rare).
 
 We break ties between multiple explanation tags by picking the less commonly used reasons, given in order below (#1 is the least commonly used and therefore wins all tiebreaks).
 
@@ -143,7 +143,7 @@ For not-helpful notes:
 **July 13, 2022**
 
 - To prevent manipulation of helpfulness scores through deletion of notes, notes that are deleted will continue to be assigned note statuses based on the ratings they received. These statuses are factored into author helpfulness scores.
-- Valid Ratings Definition Update: instead of just the first 5 ratings on a note, all ratings will be valid if they are within the first 48 hours after note creation and were created before the note first received its status of Currently Rated Helpful or Currently Rated Not Helpful (or if its status flipped between Currently Rated Helpful and Currently Rated Not Helpful, then all ratings will be valid up until that flip occurred).
+- Valid Ratings Definition Update: instead of just the first 5 ratings on a note, all ratings will be valid if they are within the first 48 hours after note creation and were created before the note first received its status of Helpful or Not Helpful (or if its status flipped between Helpful and Not Helpful, then all ratings will be valid up until that flip occurred).
 - To make the above two changes possible, we are releasing a new dataset, note status history, which contains timestamps for when each note received statuses, and the timestamp and hashed participant ID of the author of a note. This data file is being populated now and will be available on the Birdwatch [Data Download](https://twitter.com/i/birdwatch/download-data) page beginning Monday July 18, 2022.
 
 **Mar 09, 2022**
@@ -153,7 +153,7 @@ For not-helpful notes:
 
 **Feb 28, 2022**
 
-- Launched entirely new algorithm to compute note statuses (Currently Rated Helpful, Currently Not Rated Helpful), which looks for agreement across different viewpoints using a matrix factorization method. Updates contributor helpfulness scores to reflect helpfulness so that contributors whose contributions are helpful to people from a wide range of viewpoints earn higher scores. Uses helpfulness scores to identify a subset of contributor ratings to include in a final round of note scoring. This entirely replaces the previous algorithm which weighted ratings by raters’ helpfulness scores.
+- Launched entirely new algorithm to compute note statuses (Helpful, Not Helpful), which looks for agreement across different viewpoints using a matrix factorization method. Updates contributor helpfulness scores to reflect helpfulness so that contributors whose contributions are helpful to people from a wide range of viewpoints earn higher scores. Uses helpfulness scores to identify a subset of contributor ratings to include in a final round of note scoring. This entirely replaces the previous algorithm which weighted ratings by raters’ helpfulness scores.
 
 **June 30, 2021**
 

--- a/content/ranking-notes.md
+++ b/content/ranking-notes.md
@@ -85,7 +85,7 @@ Note: for now, to avoid overfitting on our very small dataset, we only use 1-dim
 
 ### Determining Note Status Explanation Tags
 
-When notes are labeled with a status (either Helpful or Not Helpful), we display the top two explanation tags that were given by raters to explain why they rated the note helpful or not.
+When notes reach a status of Helpful or Not Helpful, Birdwatch displays the top two explanation tags that were given by raters to explain why they rated the note helpful or not.
 
 This is done by simply counting the number of times each explanation tag was given filtered to explanation tags that match the final note status label (e.g., if the note status is Helpful we only count helpful explanation tags). Importantly, each explanation tag must be used by at least two different raters. If there aren’t two different tags that are each used by two different raters, then the note’s status label is reverted back to “Needs More Ratings” (this is very rare).
 

--- a/content/ranking-notes.md
+++ b/content/ranking-notes.md
@@ -12,7 +12,7 @@ geekdocToc: 1
 katex: true
 ---
 
-Birdwatch notes are submitted and rated by contributors. Ratings are used to determine note status labels (“Helpful”, “Not Helpful”, or “Needs More Ratings”). Note statuses also determine which notes are displayed on each of the [Birdwatch Site’s timelines](../birdwatch-timelines/), and which notes are displayed as [Birdwatch Cards](../notes-on-twitter/) on Tweets.
+Birdwatch notes are submitted and rated by contributors. Ratings are used to determine note statuses (“Helpful”, “Not Helpful”, or “Needs More Ratings”). Note statuses also determine which notes are displayed on each of the [Birdwatch Site’s timelines](../birdwatch-timelines/), and which notes are displayed as [Birdwatch Cards](../notes-on-twitter/) on Tweets.
 
 Only notes that indicate the Tweet as “potentially misleading” are eligible to be displayed as Birdwatch Cards on Tweets; notes that indicate the Tweet is “not misleading” are not displayed as Birdwatch Cards on Tweets. As of March 9, 2022, we have temporarily paused assigning statuses to notes that indicate the Tweet is “not misleading.” Why? People have been confused about how to rate them. As these notes are effectively making the case that the Tweet does not need a note, raters often rated them as “Unhelpful - Tweet doesn’t need a note” so as to indicate the note should not appear on the Tweet. We are planning an improvement to the rating form to resolve this confusion, and plan to resume assigning statuses to “not misleading” notes once that’s in place.
 

--- a/content/ranking-notes.md
+++ b/content/ranking-notes.md
@@ -87,7 +87,7 @@ Note: for now, to avoid overfitting on our very small dataset, we only use 1-dim
 
 When notes reach a status of Helpful or Not Helpful, Birdwatch displays the top two explanation tags that were given by raters to explain why they rated the note helpful or not.
 
-This is done by simply counting the number of times each explanation tag was given filtered to explanation tags that match the final note status label (e.g., if the note status is Helpful we only count helpful explanation tags). Importantly, each explanation tag must be used by at least two different raters. If there aren’t two different tags that are each used by two different raters, then the note’s status label is reverted back to “Needs More Ratings” (this is very rare).
+This is done by simply counting the number of times each explanation tag was given filtered to explanation tags that match the final note status (e.g., if the note status is Helpful we only count helpful explanation tags). Importantly, each explanation tag must be used by at least two different raters. If there aren’t two different tags that are each used by two different raters, then the note’s status is reverted back to “Needs More Ratings” (this is very rare).
 
 We break ties between multiple explanation tags by picking the less commonly used reasons, given in order below (#1 is the least commonly used and therefore wins all tiebreaks).
 

--- a/content/ranking-notes.md
+++ b/content/ranking-notes.md
@@ -72,7 +72,7 @@ Where lambda_i (0.03), the regularization on the intercept terms, is currently 5
 
 The resulting scores that we use for each note are the note intercept terms i_n. These scores on our current data give an approximately Normal distribution, where notes with the highest and lowest intercepts tend to have factors closer to zero.
 
-We currently set the thresholds to achieve a “Helpful” label at 0.40, including less than 10% of the notes, and our threshold to achieve a “Not Helpful” label at –0.08. However, these are far from set in stone and the way we generate status labels from note scores will evolve over time.
+We currently set the thresholds to achieve a “Helpful” status at 0.40, including less than 10% of the notes, and our threshold to achieve a “Not Helpful” status at –0.08. However, these are far from set in stone and the way we generate statuses from note scores will evolve over time.
 
 This approach has a few nice properties:
 

--- a/content/ranking-notes.md
+++ b/content/ranking-notes.md
@@ -30,7 +30,7 @@ If a note is deleted, the algorithm will still score it (using all non-deleted r
 
 Notes with a Note Helpfulness Score of 0.40 and above earn the status of Helpful. Notes with a Note Helpfulness Score less than -0.05 -0.8 \* abs(noteFactorScore) are assigned Not Helpful, where noteFactorScore is described in [Matrix Factorization](#matrix-factorization). Notes with scores in between remain with a status of Needs more Ratings.
 
-In addition to Helpful / Not Helpful statuses, labels also show the two most commonly chosen explanation tags which describe the reason the note was rated helpful or unhelpful.
+When a note reaches a status of Helpful / Not Helpful, Birdwatch also shows the two most commonly chosen explanation tags which describe the reason the note was rated helpful or unhelpful.
 
 Notes with the status Needs More Ratings remain sorted by recency (newest first), and notes with a Helpful or Not Helpful status are sorted by their Helpfulness Score.
 

--- a/content/timeline-tabs.md
+++ b/content/timeline-tabs.md
@@ -15,7 +15,7 @@ Contains Tweets sorted by reverse chronological order of when its latest note wa
 
 ### Rated Helpful
 
-Tweets in this tab have at least one note labeled Currently Rated Helpful, at least one of those Currently Rated Helpful notes must have labeled the Tweet “misinformed or potentially misleading” The Tweets that pass these filters are sorted reverse-chronologically by the timestamp of the Tweet’s first-created Currently Rated Helpful note.
+Tweets in this tab have at least one note with the status of Helpful, at least one of those Helpful notes must have labeled the Tweet “misinformed or potentially misleading”. The Tweets that pass these filters are sorted reverse-chronologically by the timestamp of the Tweet’s first-created Helpful note.
 
 ### Needs Your Help
 


### PR DESCRIPTION
**Problem**
We previously called note statuses "Currently rated helpful" and "Currently not rated helpful", which can be a mouthful and sometimes confusing.

**Solution**
We're simplifying the language to simply call these statuses "Helpful" or "Not Helpful".