### PR TITLE
modify expected path for noteStatusHistory

### DIFF
--- a/static/sourcecode/constants.py
+++ b/static/sourcecode/constants.py
@@ -32,7 +32,7 @@ minNumRatersPerNote = 5
 scoredNotesOutputPath = "scoredNotes.tsv"
 notesInputPath = "notes-00000.tsv"
 ratingsInputPath = "ratings-00000.tsv"
-noteStatusHistoryInputPath = "note_status_history-00000.tsv"
+noteStatusHistoryInputPath = "noteStatusHistory-00000.tsv"
 
 # TSV Column Names
 participantIdKey = "participantId"


### PR DESCRIPTION
this fix changes the default argument for --note_status_history_path to match the name with the note status history file is downloaded.