### PR TITLE
Update threshold for "Not Helpful" scoring

### DIFF
--- a/content/ranking-notes.md
+++ b/content/ranking-notes.md
@@ -72,7 +72,7 @@ Where lambda_i (0.03), the regularization on the intercept terms, is currently 5
 
 The resulting scores that we use for each note are the note intercept terms i_n. These scores on our current data give an approximately Normal distribution, where notes with the highest and lowest intercepts tend to have factors closer to zero.
 
-We currently set the thresholds to achieve a “Helpful” status at 0.40, including less than 10% of the notes, and our threshold to achieve a “Not Helpful” status at –0.08. However, these are far from set in stone and the way we generate statuses from note scores will evolve over time.
+We currently set the thresholds to achieve a “Helpful” status at 0.40, including less than 10% of the notes, and our threshold to achieve a “Not Helpful” status at -0.05 - 0.8 \* abs(f_n). However, these are far from set in stone and the way we generate statuses from note scores will evolve over time.
 
 This approach has a few nice properties:
 


### PR DESCRIPTION
The explanation for the "Not Helpful" status assignment was not updated [under the Matrix Factorization section](https://twitter.github.io/birdwatch/ranking-notes/#matrix-factorization:~:text=our%20threshold%20to%20achieve%20a%20%E2%80%9CNot%20Helpful%E2%80%9D%20status%20at%20%E2%80%930.08) following the ranking code update in 4e5fc4f9c19b6208085348b7b966490395d949ca.