### PR TITLE
birdwatch -> community notes in inline docs

### DIFF
--- a/static/sourcecode/explanation_tags.py
+++ b/static/sourcecode/explanation_tags.py
@@ -15,7 +15,7 @@ def top_tags(
   """Given a particular row of the scoredNotes DataFrame, determine which two
   explanation tags to assign to the note based on its ratings.
 
-  See https://twitter.github.io/birdwatch/ranking-notes/#determining-note-status-explanation-tags
+  See https://twitter.github.io/communitynotes/ranking-notes/#determining-note-status-explanation-tags
 
   Args:
       row (pd.Series): row of the scoredNotes dataframe, including a count of each tag

--- a/static/sourcecode/helpfulness_scores.py
+++ b/static/sourcecode/helpfulness_scores.py
@@ -9,7 +9,7 @@ def author_helpfulness(
   CRNHMultiplier: float = 5.0,
 ) -> pd.DataFrame:
   """Computes author helpfulness scores as described in:
-  https://twitter.github.io/birdwatch/contributor-scores/#author-helpfulness-scores
+  https://twitter.github.io/communitynotes/contributor-scores/#author-helpfulness-scores
 
   Args:
       scoredNotes (pd.DataFrame): one row per note, containing preliminary note statuses
@@ -42,7 +42,7 @@ def author_helpfulness(
 
 def _rater_helpfulness(validRatings: pd.DataFrame) -> pd.DataFrame:
   """Computes rater helpfulness scores as described in:
-  https://twitter.github.io/birdwatch/contributor-scores/#rater-helpfulness-score
+  https://twitter.github.io/communitynotes/contributor-scores/#rater-helpfulness-score
 
   Args:
       validRatings (pd.DataFrame): ratings to use
@@ -66,7 +66,7 @@ def compute_general_helpfulness_scores(
   """Given notes scored by matrix factorization, compute helpfulness scores.
   Author helpfulness scores are based on the scores of the notes you wrote.
   Rater helpfulness scores are based on how the ratings you made match up with note scores.
-  See https://twitter.github.io/birdwatch/contributor-scores/.
+  See https://twitter.github.io/communitynotes/contributor-scores/.
 
   Args:
       scoredNotes pandas.DataFrame: one row per note, containing preliminary note statuses.
@@ -116,7 +116,7 @@ def filter_ratings_by_helpfulness_scores(
   logging: bool = True,
 ):
   """Filter out ratings from raters whose helpfulness scores are too low.
-  See https://twitter.github.io/birdwatch/contributor-scores/#filtering-ratings-based-on-helpfulness-scores.
+  See https://twitter.github.io/communitynotes/contributor-scores/#filtering-ratings-based-on-helpfulness-scores.
 
   Args:
       ratingsForTraining pandas.DataFrame: unfiltered input ratings

--- a/static/sourcecode/matrix_factorization.py
+++ b/static/sourcecode/matrix_factorization.py
@@ -58,7 +58,7 @@ def run_mf(
 ) -> Tuple[pd.DataFrame, pd.DataFrame, Optional[float]]:
   """Train matrix factorization model.
 
-  See https://twitter.github.io/birdwatch/ranking-notes/#matrix-factorization
+  See https://twitter.github.io/communitynotes/ranking-notes/#matrix-factorization
 
   Args:
       ratings (pd.DataFrame): pre-filtered ratings to train on

--- a/static/sourcecode/note_ratings.py
+++ b/static/sourcecode/note_ratings.py
@@ -183,7 +183,7 @@ def get_valid_ratings(
 ) -> pd.DataFrame:
   """Determine which ratings are "valid" (used to determine rater helpfulness score)
 
-  See definition here: https://twitter.github.io/birdwatch/contributor-scores/#valid-ratings
+  See definition here: https://twitter.github.io/communitynotes/contributor-scores/#valid-ratings
 
   Args:
       ratings (pd.DataFrame)

--- a/static/sourcecode/process_data.py
+++ b/static/sourcecode/process_data.py
@@ -258,7 +258,7 @@ def preprocess_data(
 ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
   """Populate helpfulNumKey, a unified column that merges the helpfulness answers from
   the V1 and V2 rating forms together, as described in
-  https://twitter.github.io/birdwatch/ranking-notes/#helpful-rating-mapping.
+  https://twitter.github.io/communitynotes/ranking-notes/#helpful-rating-mapping.
 
   Also, filter notes that indicate the Tweet is misleading, if the flag is True.
 


### PR DESCRIPTION
The doc links in the source code refer to https://twitter.github.io/birdwatch/* rather than https://twitter.github.io/communitynotes/*. The former link is broken.