### PR TITLE
update links & references from 'Birdwatch' --> 'Community Notes' for continuity

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The algorithm that powers Community Notes can be found on the [sourcecode folder
 
 ### Community Notes data
 
-All notes and ratings are [publicly available](https://twitter.com/i/birdwatch/download-data). Instructions on how to use them can be found in the [Community Notes Guide](https://twitter.github.io/communitynotes/download-data/).
+All notes and ratings are [publicly available](https://twitter.com/i/communitynotes/download-data). Instructions on how to use them can be found in the [Community Notes Guide](https://twitter.github.io/communitynotes/download-data/).
 
 ### Community Notes paper
 

--- a/content/additional-review.md
+++ b/content/additional-review.md
@@ -51,7 +51,7 @@ If you believe a note rated “helpful” on your Tweet doesn’t add helpful co
             // get the tweet id
             var tweetId = text.split("/status/")[1].split("?")[0];
             if (tweetId.match(/^[0-9]+$/)) {
-            window.open("https://twitter.com/i/birdwatch/t/" + tweetId, "_blank");
+            window.open("https://twitter.com/i/communitynotes/t/" + tweetId, "_blank");
         } else {
             alert("Invalid Tweet URL");
         }

--- a/content/aliases.md
+++ b/content/aliases.md
@@ -21,7 +21,7 @@ It’s important that the benefits of aliases don’t come at the expense of acc
 
 ## How to choose your alias
 
-Contributors can visit [this link](https://twitter.com/i/birdwatch/u/me) to choose an alias. You'll have 5 random options to pick from, and at this time choices cannot be changed.
+Contributors can visit [this link](https://twitter.com/i/communitynotes/u/me) to choose an alias. You'll have 5 random options to pick from, and at this time choices cannot be changed.
 
 {{< figure src="../images/alias-02.png">}}
 

--- a/content/challenges.md
+++ b/content/challenges.md
@@ -49,7 +49,7 @@ It’s crucial that people feel safe contributing to Community Notes and aren’
 
 - Second, contributors have an open communication line with the Community Notes team to report any issues they experience (they can reach us by DM [@CommunityNotes](https://twitter.com/communitynotes)). Community Notes has a dedicated community manager who gathers and responds to contributors’ feedback or concerns via this handle. This provides a way for contributors to flag potential issues to the Community Notes team.
 
-- Finally, all Community Notes contributions are subject to Twitter [Rules](https://help.twitter.com/rules-and-policies/twitter-rules), [Terms of Service](https://twitter.com/tos) and [Privacy Policy](https://twitter.com/privacy). If you think note might not abide by the rules, you can report it by clicking or tapping the ••• menu on a note, and then selecting "Report”, or by using the [Report a Community Note](https://help.twitter.com/en/forms/birdwatch) form. This provides a mechanism to address violating content in notes.
+- Finally, all Community Notes contributions are subject to Twitter [Rules](https://help.twitter.com/rules-and-policies/twitter-rules), [Terms of Service](https://twitter.com/tos) and [Privacy Policy](https://twitter.com/privacy). If you think note might not abide by the rules, you can report it by clicking or tapping the ••• menu on a note, and then selecting "Report”, or by using the [Report a Community Note](https://help.twitter.com/en/forms/community-note) form. This provides a mechanism to address violating content in notes.
 
 ### Reducing the impacts of low quality contributions on the system
 

--- a/content/download-data.md
+++ b/content/download-data.md
@@ -6,7 +6,7 @@ aliases: ["/data", "/about/data", "/contributing/data"]
 
 We can't wait to learn with you!
 
-All Community Notes contributions are publicly available on the [Download Data](https://twitter.com/i/birdwatch/download-data) page of the Community Notes site so that anyone has free access to analyze the data, identify problems, and spot opportunities to make Community Notes better.
+All Community Notes contributions are publicly available on the [Download Data](https://twitter.com/i/communitynotes/download-data) page of the Community Notes site so that anyone has free access to analyze the data, identify problems, and spot opportunities to make Community Notes better.
 
 If you have questions or feedback about the Community Notes public data or would like to share your analyses of this data with us, please DM us at [@CommunityNotes](http://twitter.com/communitynotes).
 
@@ -18,13 +18,13 @@ If you have questions or feedback about the Community Notes public data or would
 
 ### Data snapshots
 
-The [Community Notes data](https://twitter.com/i/birdwatch/download-data) is released as three separate files: one containing a table representing all notes, one containing a table representing all ratings, and one containing a table with metadata about notes including what statuses they received and when. These tables can be joined together on the noteId field to create a combined dataset with information about notes and their ratings. The data is released in three separate tables/files to reduce the dataset size by avoiding data duplication (this is known as a normalized data model).
+The [Community Notes data](https://twitter.com/i/communitynotes/download-data) is released as three separate files: one containing a table representing all notes, one containing a table representing all ratings, and one containing a table with metadata about notes including what statuses they received and when. These tables can be joined together on the noteId field to create a combined dataset with information about notes and their ratings. The data is released in three separate tables/files to reduce the dataset size by avoiding data duplication (this is known as a normalized data model).
 
 Currently, we release one cumulative file each for notes, notes status history, and note ratings. However, in the future, if the data ever grows too large, we will split the data into multiple files as needed.
 
 A new snapshot of the Community Notes public data is released daily, on a best-effort basis, and technical difficulties may occur and delay the data release until the next day. We are not able to provide guarantees about when this may happen. The snapshots are cumulative files, but only contain notes and ratings that were created as of 48 hours before the dataset release time. When notes and ratings are deleted, they will no longer be released in any future versions of the data downloads, although the note status history dataset will continue to contain metadata about all scored notes even after they’ve been deleted, which includes noteId, creation time, the hashed participant ID of the note’s author, and a history of which statuses each notes received and when; however, all of the content of the note itself e.g. the note’s text will no longer be available.
 
-The [data download page in Community Notes](https://twitter.com/i/birdwatch/download-data) displays a date stamp indicating the most recent date of data included in the downloadable files.
+The [data download page in Community Notes](https://twitter.com/i/communitynotes/download-data) displays a date stamp indicating the most recent date of data included in the downloadable files.
 
 ### File structure
 

--- a/content/faq.md
+++ b/content/faq.md
@@ -61,7 +61,7 @@ The people on Twitter span a wide gamut of backgrounds and experiences, and we l
 
 {{< expand "Will researchers and others outside of Twitter be able to download and analyze the data? " >}}
 
-All Community Notes' data are made publicly available on the [Download Data](https://twitter.com/i/birdwatch/download-data) page of the Community Notes site so that anyone has free access to analyze the data, identify problems, and spot opportunities to make Community Notes better. [You can learn more about our data here.](../data)
+All Community Notes' data are made publicly available on the [Download Data](https://twitter.com/i/communitynotes/download-data) page of the Community Notes site so that anyone has free access to analyze the data, identify problems, and spot opportunities to make Community Notes better. [You can learn more about our data here.](../data)
 
 {{< /expand >}}
 
@@ -81,7 +81,7 @@ Tweet authors with Community Notes on their Tweets can request additional review
 
 All contributors and all Community Notes contributions are subject to the Twitter Rules. Failure to abide by the rules can result in removal from the Community Notes program, and/or other remediations.
 
-If you believe a note may have violated the Twitter Rules, you can report it by clicking or tapping the ••• menu on a note, and then selecting "Report”, or by using [this form](https://help.twitter.com/en/forms/birdwatch).
+If you believe a note may have violated the Twitter Rules, you can report it by clicking or tapping the ••• menu on a note, and then selecting "Report”, or by using [this form](https://help.twitter.com/en/forms/community-note).
 
 Contributors who consistently write unhelpful notes may also have their [ability to write new notes temporarily locked](../writing-ability).
 

--- a/content/getting-started.md
+++ b/content/getting-started.md
@@ -13,7 +13,7 @@ aliases: ["/getting-started"]
 
 1. <div><strong> Select an alias so you can keep your identity private</strong><label>
    As a Community Notes contributor, you can now rate the helpfulness of all notes. But first, choose an alias to contribute under (it’s like a pen name!) 
-   {{< button href="https://twitter.com/i/birdwatch/u/me" >}}Select your alias{{< /button >}}
+   {{< button href="https://twitter.com/i/communitynotes/u/me" >}}Select your alias{{< /button >}}
    </label>
       </div>
 

--- a/content/note-ranking-code.md
+++ b/content/note-ranking-code.md
@@ -7,7 +7,7 @@ geekdocToc: 1
 
 Here you can find links to code that reproduces the note scoring/ranking code that Twitter runs in production.
 
-If you download the notes, ratings, and note status history files made available on the [Data Download](https://twitter.com/i/birdwatch/download-data) page and put them in the same directory as the following files, you can then run `python main.py` to produce a `scoredNotes.tsv` file that contains note scores, statuses, and explanation tags that will match what’s running in production (as of the time the data was from).
+If you download the notes, ratings, and note status history files made available on the [Data Download](https://twitter.com/i/communitynotes/download-data) page and put them in the same directory as the following files, you can then run `python main.py` to produce a `scoredNotes.tsv` file that contains note scores, statuses, and explanation tags that will match what’s running in production (as of the time the data was from).
 
 - [main.py](../sourcecode/main.py)
 - [algorithm.py](../sourcecode/algorithm.py)

--- a/content/ranking-notes.md
+++ b/content/ranking-notes.md
@@ -228,7 +228,7 @@ For not-helpful notes:
 
 - To prevent manipulation of helpfulness scores through deletion of notes, notes that are deleted will continue to be assigned note statuses based on the ratings they received. These statuses are factored into author helpfulness scores.
 - Valid Ratings Definition Update: instead of just the first 5 ratings on a note, all ratings will be valid if they are within the first 48 hours after note creation and were created before the note first received its status of Helpful or Not Helpful (or if its status flipped between Helpful and Not Helpful, then all ratings will be valid up until that flip occurred).
-- To make the above two changes possible, we are releasing a new dataset, note status history, which contains timestamps for when each note received statuses, and the timestamp and hashed participant ID of the author of a note. This data file is being populated now and will be available on the Community Notes [Data Download](https://twitter.com/i/birdwatch/download-data) page beginning Monday July 18, 2022.
+- To make the above two changes possible, we are releasing a new dataset, note status history, which contains timestamps for when each note received statuses, and the timestamp and hashed participant ID of the author of a note. This data file is being populated now and will be available on the Community Notes [Data Download](https://twitter.com/i/communitynotes/download-data) page beginning Monday July 18, 2022.
 
 **Mar 09, 2022**
 

--- a/content/rating-notes.md
+++ b/content/rating-notes.md
@@ -8,7 +8,7 @@ There are two ways to find Tweets with Community Notes in order to rate their qu
 
 ## Rating notes on the Community Notes site
 
-Go to the [**Community Notes Home page**](https://birdwatch.twitter.com) and choose any Tweet to see notes that contributors have added to it. There are three main timelines on this page:
+Go to the [**Community Notes Home page**](https://communitynotes.twitter.com) and choose any Tweet to see notes that contributors have added to it. There are three main timelines on this page:
 
 - **Needs your help:** Contains Tweets with notes where you can have the most impact when rating. This tab is only visible to Community Notes contributors.
 

--- a/content/timeline-tabs.md
+++ b/content/timeline-tabs.md
@@ -5,7 +5,7 @@ geekdocBreadcrumb: false
 geekdocToc: 1
 ---
 
-Community Notes participants are able to view three different tabs on the [Community Notes Home](http://birdwatch.twitter.com) page. Each tab contains different sets of Tweets in different orders. In order to appear in any of these tabs, a Tweet must have received at least 100 total likes plus Retweets.
+Community Notes participants are able to view three different tabs on the [Community Notes Home](https://communitynotes.twitter.com) page. Each tab contains different sets of Tweets in different orders. In order to appear in any of these tabs, a Tweet must have received at least 100 total likes plus Retweets.
 
 {{< figure src="../images/home.png">}}
 

--- a/content/video-transcript-pile-ons.md
+++ b/content/video-transcript-pile-ons.md
@@ -4,17 +4,17 @@ geekdocBreadcrumb: false
 aliases: ["/video-transcript-pile-ons"]
 ---
 
-How does Birdwatch avoid one-sided bias? Pile-ons? Brigading? Manipulation? Abuse?
+How do Community Notes (formerly called Birdwatch) avoid one-sided bias? Pile-ons? Brigading? Manipulation? Abuse?
 
 Community Notes are rated by contributors of multiple perspectives, and only notes that are widely found helpful are shown on Tweets. So one group alone can't determine what notes get shown, and pile-ons aren't effective.
 
 This helps ensure that notes are helpful to a wide range of people.
 
-To make it clear how all of this works, Birdwatch's algorithm is open source, and all the data is public.
+To make it clear how all of this works, Community Notes' algorithm is open source, and all the data is public.
 
 See the code on Github: [twitter.github.io/communitynotes](https://twitter.github.io/communitynotes)
 
-Birdwatch
+Community Notes (formerly called Birdwatch)
 
 Context on Tweets. By the people, for the people.
 

--- a/content/video-transcript-pile-ons.md
+++ b/content/video-transcript-pile-ons.md
@@ -12,7 +12,7 @@ This helps ensure that notes are helpful to a wide range of people.
 
 To make it clear how all of this works, Birdwatch's algorithm is open source, and all the data is public.
 
-See the code on Github: [twitter.github.io/birdwatch](https://twitter.github.io/birdwatch)
+See the code on Github: [twitter.github.io/communitynotes](https://twitter.github.io/communitynotes)
 
 Birdwatch
 

--- a/content/video-transcript.md
+++ b/content/video-transcript.md
@@ -4,7 +4,7 @@ geekdocBreadcrumb: false
 aliases: ["/video-transcript"]
 ---
 
-Introducing Birdwatch.
+Introducing Community Notes (formerly called Birdwatch).
 
 Sometimes, Tweets can be misleading or miss important context.
 
@@ -12,15 +12,15 @@ Sometimes, Tweets can be misleading or miss important context.
 
 And you aren't sure whether to trust the Tweet…
 
-Birdwatch empowers people to share helpful context. Here's how it works:
+Community Notes empower people to share helpful context. Here's how it works:
 
 Contributors propose notes that add context to Tweets. Notes are then rated by other contributors.
 
-Decisions aren't made by majority rules or popularity…So one group alone can't determine what notes get shown. Instead, Birdwatch finds notes that are helpful to people with different points of view, and adds them as context to the Tweet.
+Decisions aren't made by majority rules or popularity…So one group alone can't determine what notes get shown. Instead, Community Notes finds notes that are helpful to people with different points of view, and adds them as context to the Tweet.
 
 [Cleve @All_the_sportz 1hr ago tweeted, “Police are reporting that 3 ostriches are loose in Central Station 😲. Readers added more context they thought people might want to know. Is this note helpful? Rate it. Context is written by people who use Twitter, and appears when rated helpful by others. Find out more”]
 
-Birdwatch
+Community Notes (formerly called Birdwatch)
 
 Context on Tweets. By the people, for the people.
 

--- a/content/welcome.md
+++ b/content/welcome.md
@@ -8,7 +8,7 @@ You're now a Community Notes contributor 🎉
 
 1. <div><strong> Select an alias so you can keep your identity private</strong><label>
    As a Community Notes contributor, you can now rate the helpfulness of all notes. But first, choose an alias to contribute under (it’s like a pen name!) 
-   {{< button href="https://twitter.com/i/birdwatch/u/me" >}}Select your alias{{< /button >}}
+   {{< button href="https://twitter.com/i/communitynotes/u/me" >}}Select your alias{{< /button >}}
    </label>
       </div>
 

--- a/content/writing-and-rating-impact.md
+++ b/content/writing-and-rating-impact.md
@@ -42,7 +42,7 @@ Note statuses can change any time as more ratings come in, and can be overturned
 
 ### How do I increase my Rating Impact?
 
-To increase this impact, you should look for notes that still need more ratings, and rate them. The best ways to do this are by browsing the [Needs Your Help](https://twitter.com/i/birdwatch/needs_your_help) tab in Community Notes, and by looking out for alerts when a note needs your rating.
+To increase this impact, you should look for notes that still need more ratings, and rate them. The best ways to do this are by browsing the [Needs Your Help](https://twitter.com/i/communitynotes/needs_your_help) tab in Community Notes, and by looking out for alerts when a note needs your rating.
 
 1. <div><strong> Help identify notes as Helpful</strong>
    <label>When you help a note earn the status of Helpful, it gets shown on Twitter as context, helping keep people informed.</label></div>

--- a/static/sourcecode/algorithm.py
+++ b/static/sourcecode/algorithm.py
@@ -16,7 +16,7 @@ def note_post_processing(
   userEnrollment: pd.DataFrame,
 ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
   """Given scored Birdwatch notes and rater helpfulness, calculate contributor scores and update noteStatusHistory, as described in
-  and https://twitter.github.io/birdwatch/contributor-scores/.
+  and https://twitter.github.io/communitynotes/contributor-scores/.
 
   Args:
       ratings (pd.DataFrame): preprocessed ratings
@@ -118,8 +118,8 @@ def run_algorithm(
   epochs: int = c.epochs,
   seed: Optional[int] = None,
 ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-  """Run the entire Birdwatch scoring algorithm, as described in https://twitter.github.io/birdwatch/ranking-notes/
-  and https://twitter.github.io/birdwatch/contributor-scores/.
+  """Run the entire Birdwatch scoring algorithm, as described in https://twitter.github.io/communitynotes/ranking-notes/
+  and https://twitter.github.io/communitynotes/contributor-scores/.
 
   Args:
       ratings (pd.DataFrame): preprocessed ratings

--- a/static/sourcecode/matrix_factorization.py
+++ b/static/sourcecode/matrix_factorization.py
@@ -322,7 +322,7 @@ def run_mf(
 ) -> Tuple[pd.DataFrame, pd.DataFrame, Optional[float]]:
   """Train matrix factorization model.
 
-  See https://twitter.github.io/birdwatch/ranking-notes/#matrix-factorization
+  See https://twitter.github.io/communitynotes/ranking-notes/#matrix-factorization
 
   Args:
       ratings (pd.DataFrame): pre-filtered ratings to train on


### PR DESCRIPTION
All URLs checked and confirmed working with the exception of those where alternative URL could not be found. 

**The following is not included in this PR:**
- https://twitter.com/i/flow/join-birdwatch (could not find an alternative URL)
- Any references to Birdwatch in developer's comments
- Any links pointing to a document or blog post where an alternative URL could not be found
- Any text referencing Birdwatch as a precursor to Community Notes
- /birdwatch-timelines (dead)