### PR TITLE
Add support for retro status timestamps

### DIFF
--- a/static/sourcecode/constants.py
+++ b/static/sourcecode/constants.py
@@ -1,5 +1,17 @@
+import time
+
 import numpy as np
 
+
+# Store the timestamp at which the constants module is initialized.  Note
+# that module initialization occurs only once regardless of how many times
+# the module is imported (see link below).  Storing a designated timestamp
+# as a constant allow us to:
+#  -Use a consistent notion of "now" throughout scorer execution.
+#  -Overwrite "now" when system testing to reduce spurious diffs.
+#
+# https://docs.python.org/3/tutorial/modules.html#more-on-modules
+epochMillis = 1000 * time.time()
 
 # Note Status Requirements
 minRatingsNeeded = 5
@@ -32,7 +44,6 @@ useGlobalIntercept = True
 convergence = 1e-7
 initLearningRate = 0.2
 noInitLearningRate = 1.0
-addPseudoRaters = True
 
 # Data Filters
 minNumRatingsPerRater = 10
@@ -241,7 +252,7 @@ noteTSVColumnsAndTypes = (
   + notMisleadingTagsAndTypes
   + [
     ("trustworthySources", np.int64),
-    ("summary", np.object),
+    (summaryKey, np.object),
   ]
 )
 noteTSVColumns = [col for (col, dtype) in noteTSVColumnsAndTypes]
@@ -277,6 +288,7 @@ timestampMillisOfNoteMostRecentNonNMRLabelKey = "timestampMillisOfLatestNonNMRSt
 mostRecentNonNMRLabelKey = "mostRecentNonNMRStatus"
 timestampMillisOfStatusLockKey = "timestampMillisOfStatusLock"
 lockedStatusKey = "lockedStatus"
+timestampMillisOfRetroLockKey = "timestampMillisOfRetroLock"
 
 noteStatusHistoryTSVColumnsAndTypes = [
   (noteIdKey, np.int64),
@@ -290,6 +302,7 @@ noteStatusHistoryTSVColumnsAndTypes = [
   (mostRecentNonNMRLabelKey, np.object),
   (timestampMillisOfStatusLockKey, np.double),  # double because nullable.
   (lockedStatusKey, np.object),
+  (timestampMillisOfRetroLockKey, np.double),  # double because nullable.
 ]
 noteStatusHistoryTSVColumns = [col for (col, dtype) in noteStatusHistoryTSVColumnsAndTypes]
 noteStatusHistoryTSVTypes = [dtype for (col, dtype) in noteStatusHistoryTSVColumnsAndTypes]
@@ -301,6 +314,7 @@ noteStatusHistoryTSVTypeMapping = {
 enrollmentState = "enrollmentState"
 successfulRatingNeededToEarnIn = "successfulRatingNeededToEarnIn"
 timestampOfLastStateChange = "timestampOfLastStateChange"
+timestampOfLastEarnOut = "timestampOfLastEarnOut"
 authorTopNotHelpfulTagValues = "authorTopNotHelpfulTagValues"
 maxHistoryEarnOut = 5
 successfulRatingHelpfulCount = "successfulRatingHelpfulCount"

--- a/static/sourcecode/contributor_state.py
+++ b/static/sourcecode/contributor_state.py
@@ -345,7 +345,7 @@ def get_contributor_state(
   )
 
   # We set the new contributor state.
-  contributorScoresWithEnrollment[c.timestampOfLastStateChange] = 1000 * time()
+  contributorScoresWithEnrollment[c.timestampOfLastStateChange] = c.epochMillis
   contributorScoresWithEnrollment.fillna(
     inplace=True,
     value={

--- a/static/sourcecode/note_ratings.py
+++ b/static/sourcecode/note_ratings.py
@@ -288,7 +288,11 @@ def compute_scored_notes(
       pd.DataFrame: scoredNotes The scored notes
   """
   last28Days = (
-    1000 * (datetime.now(tz=timezone.utc) - timedelta(days=c.emergingWriterDays)).timestamp()
+    1000
+    * (
+      datetime.fromtimestamp(c.epochMillis / 1000, tz=timezone.utc)
+      - timedelta(days=c.emergingWriterDays)
+    ).timestamp()
   )
   ratingsToUse = pd.DataFrame(
     ratings[[c.noteIdKey, c.helpfulNumKey] + c.helpfulTagsTSVOrder + c.notHelpfulTagsTSVOrder]

--- a/static/sourcecode/note_status_history.py
+++ b/static/sourcecode/note_status_history.py
@@ -149,7 +149,7 @@ def update_note_status_history(
   Returns:
       pd.DataFrame: noteStatusHistory
   """
-  currentTimeMillis = 1000 * time()
+  currentTimeMillis = c.epochMillis
   newScoredNotesSuffix = "_sn"
   mergedStatuses = oldNoteStatusHistory.merge(
     scoredNotes[

--- a/static/sourcecode/process_data.py
+++ b/static/sourcecode/process_data.py
@@ -76,7 +76,10 @@ def tsv_reader(path: str, mapping, columns):
 
 
 def read_from_tsv(
-  notesPath: str, ratingsPath: str, noteStatusHistoryPath: str, userEnrollmentPath: str
+  notesPath: str,
+  ratingsPath: str,
+  noteStatusHistoryPath: str,
+  userEnrollmentPath: str,
 ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
   """Mini function to read notes, ratings, and noteStatusHistory from TSVs.
 


### PR DESCRIPTION
This PR adds support for retro status timestamps, which is necessary for public code to execute on up-to-date inputs.  The PR also adds logic to make pseudoraters optional, fix the timestamp to a single value for the duration of execution and introduces a constant which will be used in an update to earn in / earn out.