### PR TITLE
Updated link ref for Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 We feel that a welcoming community is important and we ask that you follow Twitter's
-[Open Source Code of Conduct](https://github.com/twitter/code-of-conduct/blob/master/code-of-conduct.md)
+[Open Source Code of Conduct](https://github.com/twitter/.github/blob/main/code-of-conduct.md)
 in all interactions with the community.


### PR DESCRIPTION
The link ref was dead, so I updated it. 😺