### PR TITLE
Fix typo in Utilites -> Utilities. In tag_filter.py.

### DIFF
--- a/static/sourcecode/scoring/tag_filter.py
+++ b/static/sourcecode/scoring/tag_filter.py
@@ -1,4 +1,4 @@
-"""Utilites for tag based scoring logic."""
+"""Utilities for tag based scoring logic."""
 
 from typing import Dict
 


### PR DESCRIPTION
Typo fix. 