### PR TITLE
Move TSV readers to a separate module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 public
 _gen
 .DS_Store
+.idea
+__pycache__
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ public
 _gen
 .DS_Store
 .idea
-__pycache__
 *.pyc
+__pycache__/
+.pytest_cache/

--- a/sourcecode/scoring/tsv_readers/__init__.py
+++ b/sourcecode/scoring/tsv_readers/__init__.py
@@ -1,6 +1,7 @@
 from .notes_status_history_tsv_reader import NotesStatusHistoryTSVReader
 from .notes_tsv_reader import NotesTSVReader
 from .ratings_tsv_reader import RatingsTSVReader
+from .tsv_reader_base import TSVReaderBase
 from .user_enrollments_tsv_reader import UserEnrollmentsNewFormatTSVReader
 from .user_enrollments_tsv_reader import UserEnrollmentOldFormatTSVReader
 
@@ -8,6 +9,7 @@ __all__ = (
   NotesStatusHistoryTSVReader,
   NotesTSVReader,
   RatingsTSVReader,
+  TSVReaderBase,
   UserEnrollmentsNewFormatTSVReader,
   UserEnrollmentOldFormatTSVReader,
 )

--- a/sourcecode/scoring/tsv_readers/__init__.py
+++ b/sourcecode/scoring/tsv_readers/__init__.py
@@ -1,0 +1,13 @@
+from .notes_status_history_tsv_reader import NotesStatusHistoryTSVReader
+from .notes_tsv_reader import NotesTSVReader
+from .ratings_tsv_reader import RatingsTSVReader
+from .user_enrollments_tsv_reader import UserEnrollmentsNewFormatTSVReader
+from .user_enrollments_tsv_reader import UserEnrollmentOldFormatTSVReader
+
+__all__ = (
+  NotesStatusHistoryTSVReader,
+  NotesTSVReader,
+  RatingsTSVReader,
+  UserEnrollmentsNewFormatTSVReader,
+  UserEnrollmentOldFormatTSVReader,
+)

--- a/sourcecode/scoring/tsv_readers/exceptions.py
+++ b/sourcecode/scoring/tsv_readers/exceptions.py
@@ -1,0 +1,79 @@
+import typing
+
+if typing.TYPE_CHECKING:
+  from scoring.tsv_readers import tsv_reader_base
+
+
+class TSVReaderError(ValueError):
+  def __init__(self, tsv_reader: "tsv_reader_base.TSVReaderBase"):
+    self._tsv_reader_name = tsv_reader.reader_name
+    self._input_location = tsv_reader.location
+
+  @property
+  def tsv_reader_name(self) -> str:
+    return self._tsv_reader_name
+
+  @property
+  def input_location(self) -> str:
+    return self._input_location
+
+  def __str__(self) -> str:
+    return f"Invalid TSV input for {self.tsv_reader_name} from {self.input_location}"
+
+
+class IoInputNotSeekableError(TSVReaderError):
+  def __str(self) -> str:
+    super_str = super(IoInputNotSeekableError, self).__str__()
+    return f"{super_str}: IO input must be seekable."
+
+
+class EmptyInputError(TSVReaderError):
+  def __str__(self) -> str:
+    super_str = super(EmptyInputError, self).__str__()
+    return f"{super_str}: Input is empty."
+
+
+class UnexpectedColumnCountError(TSVReaderError):
+  def __init__(self, num_expected_columns: int, num_actual_columns: int, *args, **kwargs):
+    super(UnexpectedColumnCountError, self).__init__(*args, **kwargs)
+    self._num_expected_columns = num_expected_columns
+    self._num_actual_columns = num_actual_columns
+
+  @property
+  def num_expected_columns(self) -> int:
+    return self._num_expected_columns
+
+  @property
+  def num_actual_columns(self) -> int:
+    return self._num_actual_columns
+
+  def __str__(self) -> str:
+    super_str = super(UnexpectedColumnCountError, self).__str__()
+    return f"{super_str}: Expected {self.num_expected_columns} columns but got {self.num_actual_columns}."
+
+
+class UnexpectedColumnsError(TSVReaderError):
+  def __init__(
+    self,
+    extra_columns: typing.Set[str],
+    missing_columns: typing.Set[str],
+    *args,
+    **kwargs,
+  ):
+    super(UnexpectedColumnsError, self).__init__(*args, **kwargs)
+    self._extra_columns = extra_columns
+    self._missing_columns = missing_columns
+
+  @property
+  def extra_columns(self) -> typing.Set:
+    return self._extra_columns
+
+  @property
+  def missing_columns(self) -> typing.Set:
+    return self._missing_columns
+
+  def __str__(self) -> str:
+    super_str = super(UnexpectedColumnsError, self).__str__()
+    return f"{super_str}: Columns don't match:\n" \
+           f"{self.extra_columns} are extra columns,\n" \
+           f"{self.missing_columns} are missing."

--- a/sourcecode/scoring/tsv_readers/notes_status_history_tsv_reader.py
+++ b/sourcecode/scoring/tsv_readers/notes_status_history_tsv_reader.py
@@ -1,0 +1,10 @@
+import typing
+
+from scoring import constants
+from sourcecode.scoring.tsv_readers import tsv_reader_base
+
+
+class NotesStatusHistoryTSVReader(tsv_reader_base.TSVReaderBase):
+  @property
+  def _datatype_mapping(self) -> typing.Mapping[str, typing.Type]:
+    return constants.noteStatusHistoryTSVTypeMapping

--- a/sourcecode/scoring/tsv_readers/notes_tsv_reader.py
+++ b/sourcecode/scoring/tsv_readers/notes_tsv_reader.py
@@ -1,0 +1,10 @@
+import typing
+
+from scoring import constants
+from sourcecode.scoring.tsv_readers import tsv_reader_base
+
+
+class NotesTSVReader(tsv_reader_base.TSVReaderBase):
+  @property
+  def _datatype_mapping(self) -> typing.Mapping[str, typing.Type]:
+    return constants.noteTSVTypeMapping

--- a/sourcecode/scoring/tsv_readers/ratings_tsv_reader.py
+++ b/sourcecode/scoring/tsv_readers/ratings_tsv_reader.py
@@ -1,0 +1,10 @@
+import typing
+
+from scoring import constants
+from sourcecode.scoring.tsv_readers import tsv_reader_base
+
+
+class RatingsTSVReader(tsv_reader_base.TSVReaderBase):
+  @property
+  def _datatype_mapping(self) -> typing.Mapping[str, typing.Type]:
+    return constants.ratingTSVTypeMapping

--- a/sourcecode/scoring/tsv_readers/tsv_reader_base.py
+++ b/sourcecode/scoring/tsv_readers/tsv_reader_base.py
@@ -1,12 +1,45 @@
 import abc
+import io
+import pathlib
 import typing
 
 import pandas as pd
+from pandas import errors as pd_errors
+
+from scoring.tsv_readers import exceptions
 
 
 class TSVReaderBase(abc.ABC):
-  def __init__(self, path: str):
-    self._path = path
+  _TSV_SEPERATOR = "\t"
+
+  def __init__(self, buffer: typing.IO, location: str):
+    if not buffer.seekable():
+      # We read the first line twice for pre-parsing validation, se we must seek back to 0 afterwards.
+      raise exceptions.IoInputNotSeekableError(tsv_reader=self)
+
+    self._input_buffer = buffer
+    self._location = location
+
+  @property
+  def reader_name(self) -> str:
+    return self.__class__.__name__
+
+  @property
+  def location(self) -> str:
+    return self._location
+
+  @classmethod
+  def from_file(cls, path: typing.Union[str, pathlib.Path], encoding="utf8", has_header: bool = True) -> pd.DataFrame:
+    with open(file=path, mode="r", encoding=encoding) as tsv_file:
+      return cls(buffer=tsv_file, location=path).read(has_header=has_header)
+
+  @classmethod
+  def from_string(cls, raw: str, has_header: bool = True) -> pd.DataFrame:
+    return cls(buffer=io.StringIO(raw), location="string").read(has_header=has_header)
+
+  @classmethod
+  def from_buffer(cls, buffer: typing.IO, has_header: bool = True) -> pd.DataFrame:
+    return cls(buffer=buffer, location="io").read(has_header=has_header)
 
   def read(self, has_header: bool = True) -> pd.DataFrame:
     """Reads a tsv file into a pandas DataFrame, and validates the columns read are expected.
@@ -20,27 +53,46 @@ class TSVReaderBase(abc.ABC):
     try:
       self._validate_num_columns_in_file()
       results = pd.read_csv(
-        filepath_or_buffer=self._path,
-        sep=self._separator,
+        filepath_or_buffer=self._input_buffer,
+        sep=self._TSV_SEPERATOR,
         dtype=self._datatype_mapping,
-        names=self._columns,
+        names=None if has_header else self._columns,
         header=0 if has_header else None,
       )
-    except (ValueError, IndexError) as exc:
-      raise ValueError(f"Invalid TSV input at {self._path}.") from exc
+      self._verify_read_columns(results)
+    except exceptions.TSVReaderError:
+      raise
+    except pd_errors.EmptyDataError:
+      if not has_header:
+        return pd.DataFrame(columns=self._columns)
+      raise exceptions.EmptyInputError(tsv_reader=self)
+    except Exception as exc:
+      raise exceptions.TSVReaderError(tsv_reader=self) from exc
 
-    self._verify_read_columns(results)
     return results
 
   def _validate_num_columns_in_file(self) -> None:
     """Validate the number of columns in the file, against the expected amount.
     The validation is done on the raw file, by examining the first line and splitting it manually.
     """
-    with open(self._path, "r") as tsv_file:
-      num_actual_columns = len(tsv_file.readline().split(self._separator))
-      num_expected_columns = len(self._columns)
-      if num_actual_columns != num_expected_columns:
-        raise ValueError(f"Expected {num_expected_columns} columns in {self._path} but got {num_actual_columns}.")
+    first_line = self._read_first_line()
+    if not first_line:
+      # Empty file should pass the validation.
+      return
+
+    num_actual_columns = len(first_line.split(self._TSV_SEPERATOR))
+    num_expected_columns = len(self._columns)
+    if num_actual_columns != num_expected_columns:
+      raise exceptions.UnexpectedColumnCountError(
+        num_expected_columns=num_expected_columns,
+        num_actual_columns=num_actual_columns,
+        tsv_reader=self,
+      )
+
+  def _read_first_line(self) -> str:
+    first_line = self._input_buffer.readline()
+    self._input_buffer.seek(0)
+    return first_line
 
   def _verify_read_columns(self, results: pd.DataFrame) -> None:
     """
@@ -48,20 +100,16 @@ class TSVReaderBase(abc.ABC):
     Args:
         results (DataFrame): The DataFrame returned by the read method.
     Raises:
-        ValueError: if there are any extra or missing columns in the DataFrame.
+        UnexpectedColumnsError: if there are any extra or missing columns in the DataFrame.
     """
     actual_columns = set(results.columns.values)
     expected_columns = set(self._columns)
     if actual_columns != expected_columns:
-      raise ValueError(
-        f"Columns don't match for {self._path}:\n"
-        f"{actual_columns - expected_columns} are extra columns,\n"
-        f"{expected_columns - actual_columns} are missing.",
+      raise exceptions.UnexpectedColumnsError(
+        extra_columns=actual_columns - expected_columns,
+        missing_columns=expected_columns - actual_columns,
+        tsv_reader=self,
       )
-
-  @property
-  def _separator(self) -> str:
-    return "\t"
 
   @property
   @abc.abstractmethod
@@ -71,3 +119,6 @@ class TSVReaderBase(abc.ABC):
   @property
   def _columns(self) -> typing.Tuple[str, ...]:
     return tuple(self._datatype_mapping.keys())
+
+  def __repr__(self) -> str:
+    return f"{self.reader_name} from {self.location}"

--- a/sourcecode/scoring/tsv_readers/tsv_reader_base.py
+++ b/sourcecode/scoring/tsv_readers/tsv_reader_base.py
@@ -1,0 +1,73 @@
+import abc
+import typing
+
+import pandas as pd
+
+
+class TSVReaderBase(abc.ABC):
+  def __init__(self, path: str):
+    self._path = path
+
+  def read(self, has_header: bool = True) -> pd.DataFrame:
+    """Reads a tsv file into a pandas DataFrame, and validates the columns read are expected.
+
+    Args:
+      has_header: bool indicating whether the input has a header row.
+
+    Returns:
+      The data read from the provided file path, as a DataFrame.
+    """
+    try:
+      self._validate_num_columns_in_file()
+      results = pd.read_csv(
+        filepath_or_buffer=self._path,
+        sep=self._separator,
+        dtype=self._datatype_mapping,
+        names=self._columns,
+        header=0 if has_header else None,
+      )
+    except (ValueError, IndexError) as exc:
+      raise ValueError(f"Invalid TSV input at {self._path}.") from exc
+
+    self._verify_read_columns(results)
+    return results
+
+  def _validate_num_columns_in_file(self) -> None:
+    """Validate the number of columns in the file, against the expected amount.
+    The validation is done on the raw file, by examining the first line and splitting it manually.
+    """
+    with open(self._path, "r") as tsv_file:
+      num_actual_columns = len(tsv_file.readline().split(self._separator))
+      num_expected_columns = len(self._columns)
+      if num_actual_columns != num_expected_columns:
+        raise ValueError(f"Expected {num_expected_columns} columns in {self._path} but got {num_actual_columns}.")
+
+  def _verify_read_columns(self, results: pd.DataFrame) -> None:
+    """
+    Verify that the read file has exactly the columns we are expecting.
+    Args:
+        results (DataFrame): The DataFrame returned by the read method.
+    Raises:
+        ValueError: if there are any extra or missing columns in the DataFrame.
+    """
+    actual_columns = set(results.columns.values)
+    expected_columns = set(self._columns)
+    if actual_columns != expected_columns:
+      raise ValueError(
+        f"Columns don't match for {self._path}:\n"
+        f"{actual_columns - expected_columns} are extra columns,\n"
+        f"{expected_columns - actual_columns} are missing.",
+      )
+
+  @property
+  def _separator(self) -> str:
+    return "\t"
+
+  @property
+  @abc.abstractmethod
+  def _datatype_mapping(self) -> typing.Mapping[str, typing.Type]:
+    pass
+
+  @property
+  def _columns(self) -> typing.Tuple[str, ...]:
+    return tuple(self._datatype_mapping.keys())

--- a/sourcecode/scoring/tsv_readers/user_enrollments_tsv_reader.py
+++ b/sourcecode/scoring/tsv_readers/user_enrollments_tsv_reader.py
@@ -1,0 +1,23 @@
+import typing
+
+import pandas as pd
+
+from scoring import constants
+from sourcecode.scoring.tsv_readers import tsv_reader_base
+
+
+class UserEnrollmentsNewFormatTSVReader(tsv_reader_base.TSVReaderBase):
+  @property
+  def _datatype_mapping(self) -> typing.Mapping[str, typing.Type]:
+    return constants.userEnrollmentTSVTypeMapping
+
+
+class UserEnrollmentOldFormatTSVReader(tsv_reader_base.TSVReaderBase):
+  def read(self, has_header: bool = True) -> pd.DataFrame:
+    df = super(UserEnrollmentOldFormatTSVReader, self).read(has_header=has_header)
+    df[constants.modelingPopulationKey] = constants.core
+    return df
+
+  @property
+  def _datatype_mapping(self) -> typing.Mapping[str, typing.Type]:
+    return constants.userEnrollmentTSVTypeMappingOld

--- a/sourcecode/tests/test_tsv_reader.py
+++ b/sourcecode/tests/test_tsv_reader.py
@@ -1,0 +1,108 @@
+import os
+import tempfile
+import typing
+
+import pytest
+
+from scoring.tsv_readers import exceptions
+from scoring.tsv_readers import tsv_reader_base
+
+
+class TSVReader(tsv_reader_base.TSVReaderBase):
+  DATATYPE_MAPPING = {
+    "id": int,
+    "fahrenheit_temp": float,
+    "celsius_temp": float,
+    "is_valid": bool,
+    "note": str,
+  }
+
+  @property
+  def _datatype_mapping(self) -> typing.Mapping[str, typing.Type]:
+    return self.DATATYPE_MAPPING
+
+
+class TestTSVReader:
+  _VALID_HEADERS = tuple(TSVReader.DATATYPE_MAPPING.keys())
+  _VALID_DATA = (
+    (1, 32.0, 0.0, True, "Freezing"),
+    (2, 212.0, 100.0, True, "Boiling"),
+    (3, -100.2, 2.2, False, "Bad reading"),
+  )
+
+  def setup_method(self, _: typing.Callable) -> None:
+    temp_fd, self._filepath = tempfile.mkstemp(text=True)
+    os.close(temp_fd)
+
+  def teardown_method(self, _: typing.Callable) -> None:
+    os.remove(self._filepath)
+
+  def test_read_from_string(self) -> None:
+    self._write_file(headers=self._VALID_HEADERS, data=self._VALID_DATA)
+    with open(file=self._filepath, mode="r") as temp:
+      df = TSVReader.from_string(temp.read())
+    assert df.columns.values.tolist() == list(self._VALID_HEADERS)
+    assert len(df) == len(self._VALID_DATA)
+
+  def test_read_from_buffer(self) -> None:
+    self._write_file(headers=self._VALID_HEADERS, data=self._VALID_DATA)
+    with open(file=self._filepath, mode="r") as temp:
+      df = TSVReader.from_buffer(temp)
+    assert df.columns.values.tolist() == list(self._VALID_HEADERS)
+    assert len(df) == len(self._VALID_DATA)
+
+  def test_read_from_file(self) -> None:
+    self._write_file(headers=self._VALID_HEADERS, data=self._VALID_DATA)
+
+    df = TSVReader.from_file(path=self._filepath)
+    assert df.columns.values.tolist() == list(self._VALID_HEADERS)
+    assert len(df) == len(self._VALID_DATA)
+
+  def test_read_from_file_with_no_headers_row(self) -> None:
+    self._write_file(headers=None, data=self._VALID_DATA)
+
+    df = TSVReader.from_file(path=self._filepath, has_header=False)
+    assert df.columns.values.tolist() == list(self._VALID_HEADERS)
+    assert len(df) == len(self._VALID_DATA)
+
+  def test_read_from_empty_file(self) -> None:
+    with pytest.raises(exceptions.EmptyInputError):
+      TSVReader.from_file(path=self._filepath, has_header=True)
+    df = TSVReader.from_file(path=self._filepath, has_header=False)
+    assert len(df) == 0
+
+  def test_headers_count_mismatch(self) -> None:
+    headers = ("invalid_column",)
+    data = ((1,), (2,))
+    self._write_file(headers=headers, data=data)
+
+    with pytest.raises(exceptions.UnexpectedColumnCountError) as exc:
+      TSVReader.from_file(path=self._filepath)
+
+    assert exc.value.tsv_reader_name == TSVReader.__name__
+    assert exc.value.input_location == self._filepath
+    assert exc.value.num_expected_columns == len(TSVReader.DATATYPE_MAPPING)
+    assert exc.value.num_actual_columns == len(headers)
+
+  def test_header_name_mismatch(self) -> None:
+    headers = self._VALID_HEADERS[:-1] + ("invalid_column",)
+    self._write_file(headers=headers, data=self._VALID_DATA)
+
+    with pytest.raises(exceptions.UnexpectedColumnsError) as exc:
+      TSVReader.from_file(path=self._filepath)
+
+    assert exc.value.tsv_reader_name == TSVReader.__name__
+    assert exc.value.input_location == self._filepath
+    assert exc.value.missing_columns == {self._VALID_HEADERS[-1]}
+    assert exc.value.extra_columns == {headers[-1]}
+
+  def _write_file(
+    self,
+    headers: typing.Optional[typing.Sequence[str]],
+    data: typing.Sequence[typing.Sequence[typing.Any]],
+  ) -> None:
+    with open(file=self._filepath, mode="w") as temp:
+      if headers is not None:
+        temp.write("\t".join(headers) + os.linesep)
+      for line in data:
+        temp.write("\t".join(str(item) for item in line) + os.linesep)


### PR DESCRIPTION
The code is not separated enough by logic.
This PR extracts the file reading logic to a sub-module, and structures it a bit.