### PR TITLE
Add shebang to main.py

### DIFF
--- a/static/sourcecode/main.py
+++ b/static/sourcecode/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Invoke Community Notes scoring and user contribution algorithms.
 
 Example Usage:


### PR DESCRIPTION
Allow execution by writing `./main.py` instead of `python3 main.py`