### PR TITLE
Fix typo in contirbuting -> contributing. In 404.html.

### DIFF
--- a/documentation/_redirects/404.html
+++ b/documentation/_redirects/404.html
@@ -68,7 +68,7 @@
         "/sign-up": "/contributing/sign-up",
         "/signing-up": "/contributing/sign-up",
         "/timeline-tabs": "/under-the-hood/timeline-tabs",
-        "/values": "/contirbuting/values",
+        "/values": "/contributing/values",
         "/writing-ability": "/contributing/writing-ability",
         "/impact": "/contributing/writing-and-rating-impact",
         "/birdwatch-scores": "/contributing/writing-and-rating-impact",


### PR DESCRIPTION
Fix typo. This is in a <script>. I'm not entirely sure how it affects the script, but I think this fixes the typo and fixes a likely bug. 