### PR TITLE
Update timeline-tabs.md

### DIFF
--- a/documentation/timeline-tabs.md
+++ b/documentation/timeline-tabs.md
@@ -37,7 +37,7 @@ Alerts are optimized to increase the chance that potentially helpful notes on Tw
 
 **Notes are chosen based on meeting some of the following:**
 
-- Written by an author with high writing impact, or high average helpfulness score of notes they authored.
+- Written by an author with positive Writing Impact and a high ratio of Helpful notes (Writing Impact / Total Notes Written) or high average helpfulness score of notes they authored.
 - Currently have a status of "Needs More Ratings"
 - Currently have a high helpfulness score, nearing the threshold to earn status of "Helpful"
 - Do not have a large number of ratings (such that more ratings could change the note's status)


### PR DESCRIPTION
We've made a change that improves the quality of "Needs your help!" alerts sent to contributors. 

The goal behind these alerts is to quickly gather ratings on promising, high-visibility notes. Makes Community Notes faster.

Previously, notes were selected based on (among other factors), the note author's Writing Impact. This was a good start, but didn't filter out authors who have sufficient Writing Impact but write a LOT of notes of uncertain quality. Alerts now also consider the author’s hit rate — what percent of the time their notes are found helpful. Means the odds of seeing a helpful note in alerts goes up. Thanks to contributors whose feedback led to this update.