### PR TITLE
Add requirements.txt to pre-empt future package version issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ settings.json
 *.tsv
 __pycache__
 .vscode*
+communitynotes_env

--- a/README.md
+++ b/README.md
@@ -46,7 +46,24 @@ The markdown files in this repo are the source of truth for the content in our d
 
 ### Community Notes open-source code
 
-The algorithm that powers Community Notes can be found on the [sourcecode folder](https://github.com/twitter/communitynotes/tree/main/sourcecode), and instructions on how to use it can be found in the [Guide](https://twitter.github.io/communitynotes/note-ranking-code/).
+The algorithm that powers Community Notes can be found in the [sourcecode folder](https://github.com/twitter/communitynotes/tree/main/sourcecode), and instructions on how to use it can be found in the [Guide](https://twitter.github.io/communitynotes/note-ranking-code/).
+
+While your normal Python install may "just work" if you're lucky, if you run into any issues and want to install the exact versions of Python packages that we've tested the code with, please create a new virtual environment and install the packages from requirements.txt:
+
+```
+$ python -m venv communitynotes_env
+$ source communitynotes_env/bin/activate
+$ pip install -r requirements.txt
+```
+
+Then after downloading the data files (see next section) into /sourcecode/, you will be able to run:
+
+```
+$ cd sourcecode
+$ python main.py
+```
+
+Most versions of Python3 should work, but we have tested the code with Python 3.7.9.
 
 ### Community Notes data
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy==1.21.6
+pandas==1.3.5
+matplotlib==3.5.2
+tensorflow==2.5.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy==1.21.6
-pandas==1.3.5
-matplotlib==3.5.2
+numpy==1.19.2
+pandas==1.1.5
 tensorflow==2.5.0
-
+torch==1.12.0
+matplotlib==3.5.2


### PR DESCRIPTION
We had a couple bugs due to the fact that we use an older version of some major Python packages, so this PR adds requirements.txt with the specific (old... sorry) versions of packages we use.