### PR TITLE
Fix straggling np.str usage

### DIFF
--- a/sourcecode/scoring/run_scoring.py
+++ b/sourcecode/scoring/run_scoring.py
@@ -557,7 +557,7 @@ def _add_deprecated_columns(scoredNotes: pd.DataFrame) -> pd.DataFrame:
     assert column not in scoredNotes.columns
     if columnType == np.double:
       scoredNotes[column] = np.nan
-    elif columnType == np.str:
+    elif columnType == str:
       scoredNotes[column] = ""
     else:
       assert False, f"column type {columnType} unsupported"


### PR DESCRIPTION
np.str was deprecated and then causes errors in newer versions of numpy. Although we officially don't support newer versions of numpy, we might as well remove this deprecated usage.