### PR TITLE
Fixing mathjax rendering again

### DIFF
--- a/documentation/under-the-hood/ranking-notes.md
+++ b/documentation/under-the-hood/ranking-notes.md
@@ -97,12 +97,12 @@ This approach helps us to maintain data quality by recognizing when there is a t
 
 We define the quantity $a_{un}$ to represent the _weight_ given to tag $a$ identified by reviewer (user) $u$ on note $n$:
 
-$`$ a_{un} = \frac{\mathbb{1}_{a_{un}}}{ 1 + \left( {{||f_u - f_n||} \over {\tilde{f}}} \right)^5  }  $`$
+$$ a_{un} = \frac{\mathbb{1}_ {a_{un}}}{ 1 + \left( {{||f_u - f_n||} \over {\tilde{f}}} \right)^5  }  $$
 
 Where:
 
 - $\tilde{f} = \eta_{40}^{r_{un}}(||f_n - f_||)$ indicates the 40th percentile of the distances between the rater (user) and note latent factors over all observable ratings $r_{un}$
-- $`\mathbb{1}_{a_{un}}`$ is 1 if rater $u$ assigned tag $a$ to note $n$ and 0 otherwise.
+- $\mathbb{1}_ {a_{un}}$ is 1 if rater $u$ assigned tag $a$ to note $n$ and 0 otherwise.
 
 We define the total weight of an tag $a$ on note $n$ as:
 


### PR DESCRIPTION
The reason these equations were not rendering correctly is that they contain ```_{a_``` which Github tries to render as italics in Markdown.

A [previous fix](https://github.com/twitter/communitynotes/pull/131/files) introduced ``` $`$` ``` which were breaking our live website builder, because it expects only the clean `$$` delimiter . 

Here, we're fixing the issue by adding a space between the `_` and the `{a` so Github doesn't try to interpret them as an italics command.