### PR TITLE
Multiple scorer updates, mostly aimed at reducing note status flipping

### DIFF
--- a/sourcecode/scoring/constants.py
+++ b/sourcecode/scoring/constants.py
@@ -16,7 +16,7 @@ epochMillis = 1000 * time.time()
 
 maxTrainError = 0.09
 
-coreFlipPct = 0.175
+coreFlipPct = 0.09
 expansionFlipPct = 0.19
 maxReruns = 5
 

--- a/sourcecode/scoring/matrix_factorization/matrix_factorization.py
+++ b/sourcecode/scoring/matrix_factorization/matrix_factorization.py
@@ -132,7 +132,8 @@ class MatrixFactorization:
     """
     assert self.mf_model is not None
     if noteInit is not None:
-      print("initializing notes")
+      if self._logging:
+        print("initializing notes")
       noteInit = self.noteIdMap.merge(noteInit, on=c.noteIdKey, how="left")
       self.mf_model.note_intercepts.weight.data = torch.tensor(
         np.expand_dims(noteInit[c.internalNoteInterceptKey].astype(np.float32).values, axis=1)
@@ -144,7 +145,8 @@ class MatrixFactorization:
       )
 
     if userInit is not None:
-      print("initializing users")
+      if self._logging:
+        print("initializing users")
       userInit = self.raterIdMap.merge(userInit, on=c.raterParticipantIdKey, how="left")
       self.mf_model.user_intercepts.weight.data = torch.tensor(
         np.expand_dims(userInit[c.internalRaterInterceptKey].astype(np.float32).values, axis=1)
@@ -156,7 +158,8 @@ class MatrixFactorization:
       )
 
     if globalInterceptInit is not None:
-      print("initialized global intercept")
+      if self._logging:
+        print("initialized global intercept")
       self.mf_model.global_intercept = torch.nn.parameter.Parameter(
         torch.ones(1, 1) * globalInterceptInit
       )
@@ -214,7 +217,8 @@ class MatrixFactorization:
       )  # smaller learning rate
     else:
       self.optimizer = torch.optim.Adam(self.mf_model.parameters(), lr=self._noInitLearningRate)
-    print(self.mf_model.device)
+    if self._logging:
+      print(self.mf_model.device)
     self.mf_model.to(self.mf_model.device)
 
   def _instantiate_biased_mf_model(self):
@@ -225,6 +229,7 @@ class MatrixFactorization:
       n_notes,
       use_global_intercept=self._useGlobalIntercept,
       n_factors=self._numFactors,
+      logging=self._logging,
     )
     if self._logging:
       print("------------------")

--- a/sourcecode/scoring/matrix_factorization/model.py
+++ b/sourcecode/scoring/matrix_factorization/model.py
@@ -20,6 +20,7 @@ class BiasedMatrixFactorization(torch.nn.Module):
     n_notes: int,
     n_factors: int = 1,
     use_global_intercept: bool = True,
+    logging: bool = True,
   ) -> None:
     """Initialize matrix factorization model using xavier_uniform for factors
     and zeros for intercepts.
@@ -31,6 +32,8 @@ class BiasedMatrixFactorization(torch.nn.Module):
         use_global_intercept (bool, optional): Defaults to True.
     """
     super().__init__()
+
+    self._logging = logging
 
     self.user_factors = torch.nn.Embedding(n_users, n_factors, sparse=False)
     self.note_factors = torch.nn.Embedding(n_notes, n_factors, sparse=False)
@@ -78,5 +81,6 @@ class BiasedMatrixFactorization(torch.nn.Module):
     for name, param in self.named_parameters():
       for word in words_to_freeze:
         if word in name:
-          print("Freezing parameter: ", name)
+          if self._logging:
+            print("Freezing parameter: ", name)
           param.requires_grad_(False)

--- a/sourcecode/scoring/mf_base_scorer.py
+++ b/sourcecode/scoring/mf_base_scorer.py
@@ -32,7 +32,7 @@ class MFBaseScorer(Scorer):
     crnhThresholdNoteFactorMultiplier: float = -0.8,
     crnhThresholdNMIntercept: float = -0.15,
     crnhThresholdUCBIntercept: float = -0.04,
-    crhThresholdLCBIntercept: float = 0.32,
+    crhThresholdLCBIntercept: float = 0.35,
     crhSuperThreshold: float = 0.5,
     inertiaDelta: float = 0.01,
     weightedTotalVotes: float = 1.0,


### PR DESCRIPTION
1. Update the minimum LCB threshold for notes to become CRH to 0.35 from 0.32. This dramatically reduces the number of notes that become CRH due to this rule, but is necessary because notes that were becoming CRH when they had LCB intercepts between 0.32 and 0.34 were flipping back to NMR too often, so this change dramatically reduces the amount of status flipping.
2. Update maximum note status flip rate to 0.09 from 0.15, to avoid flip-flopping note statuses after the model convergences to different local modes
3. When running in parallel, read the data within each individual process rather than passing that dataset to each new process.
4. Some more refactoring for clarity.