### PR TITLE
Add tag-consensus harassment/abuse tag note scoring + reputation filtering

### DIFF
--- a/sourcecode/scoring/constants.py
+++ b/sourcecode/scoring/constants.py
@@ -60,6 +60,7 @@ ratingCreatedBeforePublicTSVReleasedKey = "ratingCreatedBeforePublicTSVReleased"
 # Timestamps
 deletedNoteTombstonesLaunchTime = 1652918400000  # May 19, 2022 UTC
 notMisleadingUILaunchTime = 1664755200000  # October 3, 2022 UTC
+lastRatingTagsChangeTimeMillis = 1639699200000  # 2021/12/15 UTC
 publicTSVTimeDelay = 172800000  # 48 hours
 
 # Explanation Tags
@@ -138,6 +139,12 @@ groupNoteInterceptMaxKey = "groupNoteInterceptMax"
 groupNoteInterceptMinKey = "groupNoteInterceptMin"
 groupRaterInterceptKey = "groupRaterIntercept"
 groupRaterFactor1Key = "groupRaterFactor1"
+# Harassment/Abuse Tag
+harassmentNoteInterceptKey = "harassmentNoteIntercept"
+harassmentNoteFactor1Key = "harassmentNoteFactor1"
+harassmentRaterInterceptKey = "harassmentRaterIntercept"
+harassmentRaterFactor1Key = "harassmentRaterFactor1"
+
 
 # Ids and Indexes
 noteIdKey = "noteId"
@@ -162,6 +169,8 @@ meanNoteScoreKey = "meanNoteScore"
 raterAgreeRatioKey = "raterAgreeRatio"
 ratingAgreesWithNoteStatusKey = "ratingAgreesWithNoteStatus"
 aboveHelpfulnessThresholdKey = "aboveHelpfulnessThreshold"
+totalHelpfulHarassmentRatingsPenaltyKey = "totalHelpfulHarassmentPenalty"
+raterAgreeRatioWithHarassmentAbusePenaltyKey = "raterAgreeRatioKeyWithHarassmentAbusePenalty"
 
 # Note Status Labels
 currentlyRatedHelpful = "CURRENTLY_RATED_HELPFUL"

--- a/sourcecode/scoring/helpfulness_scores.py
+++ b/sourcecode/scoring/helpfulness_scores.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from . import constants as c
 
 import numpy as np
@@ -70,6 +72,11 @@ def compute_general_helpfulness_scores(
   minMeanNoteScore: float,
   minCRHVsCRNHRatio: float,
   minRaterAgreeRatio: float,
+  ratings: Optional[pd.DataFrame] = None,
+  tagConsensusHarassmentAbuseNotes: Optional[pd.DataFrame] = None,
+  tagConsensusHarassmentHelpfulRatingPenalty=10,
+  multiplyPenaltyByHarassmentScore: bool = False,
+  minimumHarassmentScoreToPenalize: float = 2.5,
 ) -> pd.DataFrame:
   """Given notes scored by matrix factorization, compute helpfulness scores.
   Author helpfulness scores are based on the scores of the notes you wrote.
@@ -84,6 +91,7 @@ def compute_general_helpfulness_scores(
         comparing how often an author produces CRH / CRNH notes.  See author_helpfulness.
       minRaterAgreeRatio: minimum standard for how often a rater must predict the
         eventual outcome when rating before a note is assigned status.
+      ratings: all ratings (to check if tag-consensus harassment/abuse notes were rated helpful)
   Returns:
       helpfulness_scores pandas.DataFrame: 1 row per user, with helpfulness scores as columns.
   """
@@ -101,26 +109,67 @@ def compute_general_helpfulness_scores(
         c.crhCrnhRatioDifferenceKey,
         c.meanNoteScoreKey,
         c.raterAgreeRatioKey,
+        c.ratingAgreesWithNoteStatusKey,
+        c.ratingCountKey,
       ]
     ]
   )
 
+  if (ratings is None) or (tagConsensusHarassmentAbuseNotes is None):
+    helpfulnessScores[c.totalHelpfulHarassmentRatingsPenaltyKey] = 0
+  else:
+    filteredAbuseNotes = tagConsensusHarassmentAbuseNotes[
+      tagConsensusHarassmentAbuseNotes[c.harassmentNoteInterceptKey]
+      >= minimumHarassmentScoreToPenalize
+    ]
+    helpfulRatingsOnBadNotes = ratings[ratings[c.helpfulNumKey] == 1].merge(
+      filteredAbuseNotes, on=c.noteIdKey
+    )
+
+    helpfulRatingsOnBadNotes[
+      c.totalHelpfulHarassmentRatingsPenaltyKey
+    ] = tagConsensusHarassmentHelpfulRatingPenalty
+    if multiplyPenaltyByHarassmentScore:
+      helpfulRatingsOnBadNotes[c.totalHelpfulHarassmentRatingsPenaltyKey] *= (
+        helpfulRatingsOnBadNotes[c.harassmentNoteInterceptKey] / minimumHarassmentScoreToPenalize
+      )
+
+    helpfulRatingsOnBadNotesCount = (
+      helpfulRatingsOnBadNotes.groupby(c.raterParticipantIdKey)
+      .sum()[[c.totalHelpfulHarassmentRatingsPenaltyKey]]
+      .reset_index()
+    )
+    helpfulnessScores = helpfulnessScores.merge(
+      helpfulRatingsOnBadNotesCount, on=c.raterParticipantIdKey, how="left"
+    )
+    helpfulnessScores[c.totalHelpfulHarassmentRatingsPenaltyKey].fillna(0, inplace=True)
+
+  helpfulnessScores[c.raterAgreeRatioWithHarassmentAbusePenaltyKey] = (
+    helpfulnessScores[c.ratingAgreesWithNoteStatusKey]
+    - helpfulnessScores[c.totalHelpfulHarassmentRatingsPenaltyKey]
+  ) / helpfulnessScores[c.ratingCountKey]
+
   helpfulnessScores[c.aboveHelpfulnessThresholdKey] = (
     (
-      (helpfulnessScores[c.crhCrnhRatioDifferenceKey] >= minCRHVsCRNHRatio)
-      & (helpfulnessScores[c.meanNoteScoreKey] >= minMeanNoteScore)
+      (
+        (helpfulnessScores[c.crhCrnhRatioDifferenceKey] >= minCRHVsCRNHRatio)
+        & (helpfulnessScores[c.meanNoteScoreKey] >= minMeanNoteScore)
+      )
+      | (
+        pd.isna(helpfulnessScores[c.crhCrnhRatioDifferenceKey])
+        & pd.isna(helpfulnessScores[c.meanNoteScoreKey])
+      )
+      | (
+        pd.isna(helpfulnessScores[c.crhCrnhRatioDifferenceKey])
+        & helpfulnessScores[c.meanNoteScoreKey]
+        >= minMeanNoteScore
+      )
     )
-    | (
-      pd.isna(helpfulnessScores[c.crhCrnhRatioDifferenceKey])
-      & pd.isna(helpfulnessScores[c.meanNoteScoreKey])
-    )
-    | (
-      pd.isna(helpfulnessScores[c.crhCrnhRatioDifferenceKey])
-      & helpfulnessScores[c.meanNoteScoreKey]
-      >= minMeanNoteScore
-    )
-  ) & (helpfulnessScores[c.raterAgreeRatioKey] >= minRaterAgreeRatio)
+    & (helpfulnessScores[c.raterAgreeRatioKey] >= minRaterAgreeRatio)
+    & (helpfulnessScores[c.raterAgreeRatioWithHarassmentAbusePenaltyKey] >= minRaterAgreeRatio)
+  )
 
+  helpfulnessScores.drop(columns=[c.ratingCountKey, c.ratingAgreesWithNoteStatusKey], inplace=True)
   return helpfulnessScores
 
 

--- a/sourcecode/scoring/mf_core_scorer.py
+++ b/sourcecode/scoring/mf_core_scorer.py
@@ -19,6 +19,7 @@ class MFCoreScorer(MFBaseScorer):
     pseudoraters: Optional[bool] = False,
     core_threshold: float = 0.5,
     useStableInitialization: bool = True,
+    saveIntermediateState: bool = False,
   ) -> None:
     """Configure MFCoreScorer object.
 
@@ -28,7 +29,12 @@ class MFCoreScorer(MFBaseScorer):
       core_threshold: float specifying the fraction of reviews which must be from CORE users
         for a note to be in scope for the CORE model.
     """
-    super().__init__(seed, pseudoraters, useStableInitialization=useStableInitialization)
+    super().__init__(
+      seed,
+      pseudoraters,
+      useStableInitialization=useStableInitialization,
+      saveIntermediateState=saveIntermediateState,
+    )
     self._core_threshold = core_threshold
 
   def _get_note_col_mapping(self) -> Dict[str, str]:

--- a/sourcecode/scoring/mf_expansion_scorer.py
+++ b/sourcecode/scoring/mf_expansion_scorer.py
@@ -5,13 +5,23 @@ from .mf_base_scorer import MFBaseScorer
 
 
 class MFExpansionScorer(MFBaseScorer):
-  def __init__(self, seed: Optional[int] = None, useStableInitialization: bool = True) -> None:
+  def __init__(
+    self,
+    seed: Optional[int] = None,
+    useStableInitialization: bool = True,
+    saveIntermediateState: bool = False,
+  ) -> None:
     """Configure MFExpansionScorer object.
 
     Args:
       seed: if not None, seed value to ensure deterministic execution
     """
-    super().__init__(seed, pseudoraters=False, useStableInitialization=useStableInitialization)
+    super().__init__(
+      seed,
+      pseudoraters=False,
+      useStableInitialization=useStableInitialization,
+      saveIntermediateState=saveIntermediateState,
+    )
 
   def _get_note_col_mapping(self) -> Dict[str, str]:
     """Returns a dict mapping default note column names to custom names for a specific model."""

--- a/sourcecode/scoring/mf_group_scorer.py
+++ b/sourcecode/scoring/mf_group_scorer.py
@@ -39,6 +39,7 @@ def _coalesce_columns(df: pd.DataFrame, columnPrefix: str) -> pd.DataFrame:
   # Validate that at most one column is set, and store which rows have a column set
   rowResults = np.invert(df[columns].isna()).sum(axis=1)
   assert all(rowResults <= 1), "each row should only be in one modeling group"
+
   # Coalesce results
   def _get_value(row):
     idx = row.first_valid_index()
@@ -91,6 +92,7 @@ class MFGroupScorer(MFBaseScorer):
     seed: Optional[int] = None,
     pseudoraters: Optional[bool] = False,
     groupThreshold: float = 0.8,
+    saveIntermediateState: bool = False,
   ) -> None:
     """Configure MFGroupScorer object.
 
@@ -108,7 +110,9 @@ class MFGroupScorer(MFBaseScorer):
       groupThreshold: float indicating what fraction of ratings must be from within a group
         for the model to be active
     """
-    super().__init__(seed, pseudoraters, useStableInitialization=False)
+    super().__init__(
+      seed, pseudoraters, useStableInitialization=False, saveIntermediateState=saveIntermediateState
+    )
     assert groupNumber > 0, "groupNumber must be positive.  0 is reserved for unassigned."
     assert groupNumber <= groupScorerCount, "groupNumber exceeds maximum expected groups."
     self._groupNumber = groupNumber

--- a/sourcecode/scoring/tag_consensus.py
+++ b/sourcecode/scoring/tag_consensus.py
@@ -1,0 +1,90 @@
+from . import constants as c, process_data
+from .matrix_factorization.matrix_factorization import MatrixFactorization
+
+import pandas as pd
+
+
+def train_tag_model(
+  ratings: pd.DataFrame,
+  tag: str = c.notHelpfulSpamHarassmentOrAbuseTagKey,
+  useSigmoidCrossEntropy: bool = True,
+):
+  print(f"-------------------Training for tag {tag}-------------------")
+  ratingDataForTag, labelColName = prepare_tag_data(ratings, tag)
+  if ratingDataForTag is None or len(ratingDataForTag) == 0:
+    print(f"No valid data for {tag}, returning None and aborting {tag} model training.")
+    return None, None, None
+
+  posRate = ratingDataForTag[labelColName].sum() / len(ratingDataForTag)
+  print(f"{tag} Positive Rate: {posRate}")
+  if pd.isna(posRate) or posRate == 0 or posRate == 1:
+    print(
+      f"{tag} tag positive rate is {posRate}: returning None and aborting {tag} model training."
+    )
+    return None, None, None
+
+  if useSigmoidCrossEntropy:
+    posWeight = (1 - posRate) / posRate
+  else:
+    posWeight = None
+
+  # Train
+  mf = MatrixFactorization(
+    labelCol=labelColName,
+    useSigmoidCrossEntropy=useSigmoidCrossEntropy,
+    posWeight=posWeight,
+  )
+  noteParams, raterParams, globalBias = mf.run_mf(ratingDataForTag)
+  noteParams.columns = [col.replace("internal", "harassment") for col in noteParams.columns]
+  raterParams.columns = [col.replace("internal", "harassment") for col in raterParams.columns]
+  return noteParams, raterParams, globalBias
+
+
+def prepare_tag_data(
+  allRatings: pd.DataFrame,
+  tagName: str = c.notHelpfulIncorrectTagKey,
+  minNumRatingsPerRater: int = 10,
+  minNumRatersPerNote: int = 5,
+):
+  ratings = allRatings.loc[
+    allRatings[c.createdAtMillisKey] >= c.lastRatingTagsChangeTimeMillis
+  ].copy()
+  if len(ratings) == 0:
+    return None, None
+
+  labelColName = tagName + "Label"
+  ratings.loc[:, labelColName] = None
+
+  if tagName.startswith("helpful"):
+    oppositeValenceHelpfulness = c.notHelpfulValueTsv
+    sameValenceOtherTag = c.helpfulOtherTagKey
+  elif tagName.startswith("notHelpful"):
+    oppositeValenceHelpfulness = c.helpfulValueTsv
+    sameValenceOtherTag = c.notHelpfulOtherTagKey
+  else:
+    raise Exception("Tag unsupported.")
+
+  # Negatives: opposite helpful rating, or same-valence rating with other tag (and no target tag)
+  ratings.loc[ratings[c.helpfulnessLevelKey] == oppositeValenceHelpfulness, labelColName] = 0
+  # Treat a same-valence rating as negative if the tag used was other
+  #  (other is the only tag uncorrelated enough with other tags))
+  ## Will be set to True later if the tag itself was also true
+  ratings.loc[ratings[sameValenceOtherTag] == 1, labelColName] = 0
+
+  # Positives
+  ratings.loc[ratings[tagName] == 1, labelColName] = 1
+
+  print("Pre-filtering tag label breakdown", ratings.groupby(labelColName).size())
+  print("Number of rows with no tag label", ratings[labelColName].isnull().sum())
+
+  # Currently leave in raters who only made one type of rating, but can throw them out in the future.
+  ratings = process_data.filter_ratings(
+    ratings[ratings[labelColName].notnull()], minNumRatingsPerRater, minNumRatersPerNote
+  )
+
+  print("Post-filtering tag label breakdown", ratings.groupby(labelColName).size())
+  print("Number of rows with no tag label", ratings[labelColName].isnull().sum())
+
+  ratings[labelColName] = ratings[labelColName].astype(int)
+
+  return ratings, labelColName


### PR DESCRIPTION
-After the 1st phase matrix factorization, compute a new matrix factorization with the harassment/abuse tag as the label, instead of the overall helpful rating like normal. 
-Add a large rater reputation penalty on raters who have rated any notes with extremely high harassment/abuse scores as helpful 
-Support BCEWithLogits loss and pos_weight in order to train the imbalanced binary matrix factorization well