### PR TITLE
data loader: ignore old pd idx from multiple files

### DIFF
--- a/sourcecode/main.py
+++ b/sourcecode/main.py
@@ -2,10 +2,20 @@
 """Invoke Community Notes scoring and user contribution algorithms.
 
 Example Usage:
+  # If there is only one rating file, pass the file path to the --ratings flag.
   python main.py \
     --enrollment data/userEnrollment-00000.tsv \
     --notes data/notes-00000.tsv \
     --ratings data/ratings-00000.tsv \
+    --status data/noteStatusHistory-00000.tsv \
+    --outdir data
+
+  # If there are multiple rating files, move them to a directory, 
+  # and pass the directory path to the --ratings flag.
+  python main.py \
+    --enrollment data/userEnrollment-00000.tsv \
+    --notes data/notes-00000.tsv \
+    --ratings data/ratings \
     --status data/noteStatusHistory-00000.tsv \
     --outdir data
 """

--- a/sourcecode/scoring/process_data.py
+++ b/sourcecode/scoring/process_data.py
@@ -82,7 +82,7 @@ def tsv_reader(path: str, mapping, columns, header=False, parser=tsv_parser):
   """Read a single TSV file or a directory of TSV files."""
   if os.path.isdir(path):
     dfs = [tsv_reader_single(os.path.join(path, filename), mapping, columns, header, parser) for filename in os.listdir(path) if filename.endswith(".tsv")]
-    return pd.concat(dfs)
+    return pd.concat(dfs, ignore_index=True)
   else:
     return tsv_reader_single(path, mapping, columns, header, parser)
 


### PR DESCRIPTION
We should pass the option `ignore_index=True` when concatenating multiple pandas dataframes. It is usually ok, but if one wants to query the merged dataframe by calling the row index, having conflicted indexes is not desirable. 

I add a usage comment about how to concatenate multiple rating files in `main.py`.

Related issue: https://github.com/twitter/communitynotes/issues/150