### PR TITLE
spelling correction for "palestine"

### DIFF
--- a/sourcecode/scoring/topic_model.py
+++ b/sourcecode/scoring/topic_model.py
@@ -38,7 +38,7 @@ class TopicModel(object):
       },
       Topics.GazaConflict: {
         "israel",
-        "palestin",
+        "palestine",
         "gaza",
         "jerusalem",
       },


### PR DESCRIPTION
Spelling correction for "palestine".