### PR TITLE
Split scoring binary into separate prescoring and final scoring binaries

### DIFF
--- a/documentation/under-the-hood/note-ranking-code.md
+++ b/documentation/under-the-hood/note-ranking-code.md
@@ -8,3 +8,5 @@ navWeight: 2
 Here you can find links to code that reproduces the note scoring/ranking code that X runs in production: [code on Github](https://github.com/twitter/communitynotes/tree/main/sourcecode).
 
 If you download the data files made available on the [Data Download](https://x.com/i/communitynotes/download-data) page and put them in the same directory as the following code files, you can then run `python main.py` to produce a `scoredNotes.tsv` file that contains note scores, statuses, and explanation tags that will match what’s running in production (as of the time the data was from).
+
+Note that the algorithm is split into two main binaries: prescoring and final scoring. In production at X, each binary is run separately as often as possible, each always reading the most recent input data available. One subtle implication of this is that in order to exactly reproduce the scoring results as they are run in production at X, the prescorer should be run on input data that's 1 hour older than the final scorer (although this makes very little difference in practice).

--- a/documentation/under-the-hood/ranking-notes.md
+++ b/documentation/under-the-hood/ranking-notes.md
@@ -303,16 +303,29 @@ For not-helpful notes:
 
 ## Complete Algorithm Steps:
 
+# Prescoring
+
 1. Pre-filter the data: to address sparsity issues, only raters with at least 10 ratings and notes with at least 5 ratings are included (although we don’t recursively filter until convergence).
-2. Fit matrix factorization model, then assign intermediate note status labels for notes whose intercept terms (scores) are above or below thresholds.
-3. Compute Author and Rater Helpfulness Scores based on the results of the first matrix factorization, then filter out raters with low helpfulness scores from the ratings data as described in [Filtering Ratings Based on Helpfulness Scores](./contributor-scores.md).
-4. Re-fit the matrix factorization model on the ratings data that’s been filtered further in step 3.
-5. Compute upper and lower confidence bounds on each note's intercept by adding pseudo-ratings and re-fitting the model with them.
-6. Reconcile scoring results from the Core, Expansion, Group and Topic models to generate final status for each note.
-7. Update status labels for any notes written within the last two weeks based the intercept terms (scores) and rating tags.  Stabilize helpfulness status for any notes older than two weeks.
-8. Assign the top two explanation tags that match the note’s final status label as in [Determining Note Status Explanation Tags](#determining-note-status-explanation-tags), or if two such tags don’t exist, then revert the note status label to “Needs More Ratings”.
+2. For each scorer (Core, Expansion, and multiple Group and Topic scorers):
+    - Fit matrix factorization model, then assign intermediate note status labels for notes whose intercept terms (scores) are above or below thresholds.
+    - Compute Author and Rater Helpfulness Scores based on the results of the first matrix factorization, then filter out raters with low helpfulness scores from the ratings data as described in [Filtering Ratings Based on Helpfulness Scores](./contributor-scores.md).
+    - Fit the harassment-abuse tag-consensus matrix factorization model on the helpfulness-score filtered ratings, then update Author and Rater Helpfulness scores using the output of the tag-consensus model.
+
+# Scoring
+
+1. Load the output of step 2 above from prescoring, but re-run step 1 on the newest available notes and ratings data.
+2. For each scorer (Core, Expansion, and multiple Group and Topic scorers):
+    - Re-fit the matrix factorization model on ratings data that’s been filtered by user helpfulness scores in step 3.
+    - Fit the note diligence matrix factorization model.
+    - Compute upper and lower confidence bounds on each note's intercept by adding pseudo-ratings and re-fitting the model with them.
+3. Reconcile scoring results from each scorer to generate final status for each note.
+4. Update status labels for any notes written within the last two weeks based the intercept terms (scores) and rating tags.  Stabilize helpfulness status for any notes older than two weeks.
+5. Assign the top two explanation tags that match the note’s final status label as in [Determining Note Status Explanation Tags](#determining-note-status-explanation-tags), or if two such tags don’t exist, then revert the note status label to “Needs More Ratings”.
 
 ## What’s New?
+
+**April 11, 2024**
+- Split the scorer into separate prescoring and final scoring phases.
 
 **March 29, 2024**
 - Modify Topic Models to remove rating filters when computing note intercepts and factors.

--- a/documentation/under-the-hood/ranking-notes.md
+++ b/documentation/under-the-hood/ranking-notes.md
@@ -306,7 +306,7 @@ For not-helpful notes:
 # Prescoring
 
 1. Pre-filter the data: to address sparsity issues, only raters with at least 10 ratings and notes with at least 5 ratings are included (although we don’t recursively filter until convergence).
-2. For each scorer (Core, Expansion, and multiple Group and Topic scorers):
+2. For each scorer (Core, Expansion, ExpansionPlus, and multiple Group and Topic scorers):
     - Fit matrix factorization model, then assign intermediate note status labels for notes whose intercept terms (scores) are above or below thresholds.
     - Compute Author and Rater Helpfulness Scores based on the results of the first matrix factorization, then filter out raters with low helpfulness scores from the ratings data as described in [Filtering Ratings Based on Helpfulness Scores](./contributor-scores.md).
     - Fit the harassment-abuse tag-consensus matrix factorization model on the helpfulness-score filtered ratings, then update Author and Rater Helpfulness scores using the output of the tag-consensus model.
@@ -314,7 +314,7 @@ For not-helpful notes:
 # Scoring
 
 1. Load the output of step 2 above from prescoring, but re-run step 1 on the newest available notes and ratings data.
-2. For each scorer (Core, Expansion, and multiple Group and Topic scorers):
+2. For each scorer (Core, Expansion, ExpansionPlus, and multiple Group and Topic scorers):
     - Re-fit the matrix factorization model on ratings data that’s been filtered by user helpfulness scores in step 3.
     - Fit the note diligence matrix factorization model.
     - Compute upper and lower confidence bounds on each note's intercept by adding pseudo-ratings and re-fitting the model with them.

--- a/sourcecode/scoring/contributor_state.py
+++ b/sourcecode/scoring/contributor_state.py
@@ -26,7 +26,7 @@ def should_earn_in(contributorScoresWithEnrollment: pd.DataFrame):
   )
 
 
-def is_at_risk(authorEnrollmentCounts: pd.DataFrame):
+def newly_at_risk(authorEnrollmentCounts: pd.DataFrame):
   """
   The author is at risk when they have written 2 CRNH notes of the last 5 notes. NewUser
   EarnedOutNoAck, and EarnedOutAcknowledged states cannot transition to this state because they cannot
@@ -39,6 +39,7 @@ def is_at_risk(authorEnrollmentCounts: pd.DataFrame):
     (authorEnrollmentCounts[c.enrollmentState] != c.newUser)
     & (authorEnrollmentCounts[c.enrollmentState] != c.earnedOutNoAcknowledge)
     & (authorEnrollmentCounts[c.enrollmentState] != c.earnedOutAcknowledged)
+    & (authorEnrollmentCounts[c.enrollmentState] != c.atRisk)
     & (authorEnrollmentCounts[c.notesCurrentlyRatedNotHelpful] == c.isAtRiskCRNHCount)
   )
 
@@ -60,7 +61,7 @@ def is_earned_out(authorEnrollmentCounts: pd.DataFrame):
   )
 
 
-def is_earned_in(authorEnrollmentCounts):
+def newly_earned_in(authorEnrollmentCounts):
   """
   The author is at earned out when they have written <2 CRNH notes of the last 5 notes.
   NewUser, EarnedOutNoAck, and EarnedOutAcknowledged states cannot transition to this state because they cannot
@@ -73,6 +74,7 @@ def is_earned_in(authorEnrollmentCounts):
     (authorEnrollmentCounts[c.enrollmentState] != c.newUser)
     & (authorEnrollmentCounts[c.enrollmentState] != c.earnedOutAcknowledged)
     & (authorEnrollmentCounts[c.enrollmentState] != c.earnedOutNoAcknowledge)
+    & (authorEnrollmentCounts[c.enrollmentState] != c.earnedIn)
     & (authorEnrollmentCounts[c.notesCurrentlyRatedNotHelpful] < c.isAtRiskCRNHCount)
   )
 
@@ -324,13 +326,51 @@ def is_emerging_writer(scoredNotes: pd.DataFrame):
   return emergingWriter[[c.noteAuthorParticipantIdKey, c.isEmergingWriterKey]]
 
 
+def single_trigger_earn_out(contributorScoresWithEnrollment: pd.DataFrame) -> pd.DataFrame:
+  """
+  A function that earns out users with a negative writing impact upon any CRNH note
+  Args:
+      contributorScoresWithEnrollment (pd.DataFrame): contributor scores with state and current enrollment
+  Returns:
+    pd.DataFrame: updated contributor scores reflecting single trigger earned out users
+  """
+  earnedOutUsers = (
+    (
+      contributorScoresWithEnrollment[c.notesCurrentlyRatedNotHelpful].fillna(0, inplace=False)
+      > contributorScoresWithEnrollment[c.notesCurrentlyRatedHelpful].fillna(0, inplace=False)
+    )
+    & (contributorScoresWithEnrollment[c.hasCrnhSinceEarnOut] == True)
+    & (
+      contributorScoresWithEnrollment[c.enrollmentState]
+      != c.enrollmentStateToThrift[c.earnedOutNoAcknowledge]
+    )
+    & (
+      contributorScoresWithEnrollment[c.enrollmentState]
+      != c.enrollmentStateToThrift[c.earnedOutAcknowledged]
+    )
+    & (contributorScoresWithEnrollment[c.enrollmentState] != c.enrollmentStateToThrift[c.newUser])
+  )
+
+  contributorScoresWithEnrollment.loc[earnedOutUsers, c.numberOfTimesEarnedOutKey] = (
+    contributorScoresWithEnrollment.loc[earnedOutUsers, c.numberOfTimesEarnedOutKey] + 1
+  )
+
+  # use earned out no ack internally to identify newly earned out users
+  contributorScoresWithEnrollment.loc[
+    earnedOutUsers, c.enrollmentState
+  ] = c.enrollmentStateToThrift[c.earnedOutNoAcknowledge]
+  contributorScoresWithEnrollment.loc[earnedOutUsers, c.timestampOfLastStateChange] = c.epochMillis
+
+  return contributorScoresWithEnrollment.drop(columns=[c.hasCrnhSinceEarnOut])
+
+
 def calculate_ri_to_earn_in(contributorScoresWithEnrollment: pd.DataFrame) -> pd.DataFrame:
   """
-  A function updates rating impact needed to earn in for earned out users
+  A function that updates rating impact needed to earn in for earned out users
   Args:
-      scoredNotes (pd.DataFrame): scored notes
+      contributorScoresWithEnrollment (pd.DataFrame): contributor scores with state and current enrollment
   Returns:
-    pd.DataFrame: emergingWriter The contributor scores with enrollments
+    pd.DataFrame: dataframe with updated rating impact required to earn in for earned out users
   """
   earnedOutUsers = (
     contributorScoresWithEnrollment[c.enrollmentState]
@@ -342,7 +382,7 @@ def calculate_ri_to_earn_in(contributorScoresWithEnrollment: pd.DataFrame) -> pd
   ] = contributorScoresWithEnrollment.apply(
     lambda row: c.ratingImpactForEarnIn
     + max([row[c.ratingImpact], 0])
-    + (c.ratingImpactForEarnIn * row[c.numberOfTimesEarnedOutKey]),
+    + (c.ratingImpactForEarnIn * max(row[c.numberOfTimesEarnedOutKey] - 1, 0)),
     axis=1,
   ).loc[earnedOutUsers]
 
@@ -388,7 +428,7 @@ def get_contributor_state(
     # for users in state Earned Out Ack, update the timestamp of last earn out; this ensures they are only judged against
     # their rating target until they resume writing notes
     userEnrollment.loc[
-      userEnrollment[c.enrollmentState] == 3, c.timestampOfLastEarnOut
+      userEnrollment[c.enrollmentState] == c.earnedOutAcknowledged, c.timestampOfLastEarnOut
     ] = c.epochMillis
 
     # We need to consider only the last 5 notes for enrollment state. The ratings are aggregated historically.
@@ -409,6 +449,8 @@ def get_contributor_state(
       sinceLastEarnOut=True,
     )
     contributorScores.fillna(0, inplace=True)
+
+  contributorScores[c.hasCrnhSinceEarnOut] = contributorScores[c.notesCurrentlyRatedNotHelpful] > 0
 
   with c.time_block("Contributor State: Top NH Tags Per Author"):
     # We merge in the top not helpful tags
@@ -439,7 +481,6 @@ def get_contributor_state(
     )
 
     # We set the new contributor state.
-    contributorScoresWithEnrollment[c.timestampOfLastStateChange] = c.epochMillis
     contributorScoresWithEnrollment.fillna(
       inplace=True,
       value={
@@ -459,8 +500,15 @@ def get_contributor_state(
       should_earn_in(contributorScoresWithEnrollment), c.enrollmentState
     ] = c.enrollmentStateToThrift[c.earnedIn]
     contributorScoresWithEnrollment.loc[
-      is_at_risk(contributorScoresWithEnrollment), c.enrollmentState
+      should_earn_in(contributorScoresWithEnrollment), c.timestampOfLastStateChange
+    ] = c.epochMillis
+
+    contributorScoresWithEnrollment.loc[
+      newly_at_risk(contributorScoresWithEnrollment), c.enrollmentState
     ] = c.enrollmentStateToThrift[c.atRisk]
+    contributorScoresWithEnrollment.loc[
+      newly_at_risk(contributorScoresWithEnrollment), c.timestampOfLastStateChange
+    ] = c.epochMillis
 
     # for earned out users, first increment the number of times they have earned out,
     # use this to overwrite successful rating needed to earn in,
@@ -476,12 +524,30 @@ def get_contributor_state(
     ] = c.enrollmentStateToThrift[c.earnedOutNoAcknowledge]
 
     contributorScoresWithEnrollment.loc[
-      is_earned_in(contributorScoresWithEnrollment), c.enrollmentState
+      earnedOutUsers, c.timestampOfLastStateChange
+    ] = c.epochMillis
+
+    # at risk users transitioning back to earned in
+    contributorScoresWithEnrollment.loc[
+      newly_earned_in(contributorScoresWithEnrollment), c.enrollmentState
     ] = c.enrollmentStateToThrift[c.earnedIn]
+    contributorScoresWithEnrollment.loc[
+      newly_earned_in(contributorScoresWithEnrollment), c.timestampOfLastStateChange
+    ] = c.epochMillis
 
     contributorScoresWithEnrollment[c.enrollmentState] = contributorScoresWithEnrollment[
       c.enrollmentState
     ].map(_transform_to_thrift_code)
+
+    mappedUserEnrollment = userEnrollment[
+      [c.participantIdKey, c.timestampOfLastEarnOut, c.enrollmentState]
+    ]
+    mappedUserEnrollment[c.enrollmentState] = mappedUserEnrollment[c.enrollmentState].map(
+      _transform_to_thrift_code
+    )
+    mappedUserEnrollment = mappedUserEnrollment.rename(
+      columns={c.enrollmentState: c.enrollmentState + "_prev"}
+    )
 
     # This addresses an issue in the TSV dump in HDFS getting corrupted. It removes lines
     # users that do not have an id.
@@ -510,7 +576,7 @@ def get_contributor_state(
       len(contributorScoresWithEnrollment[contributorScoresWithEnrollment[c.enrollmentState] == 4]),
     )
 
-  return contributorScoresWithEnrollment
+  return contributorScoresWithEnrollment, mappedUserEnrollment
 
 
 def get_contributor_scores(

--- a/sourcecode/scoring/matrix_factorization/matrix_factorization.py
+++ b/sourcecode/scoring/matrix_factorization/matrix_factorization.py
@@ -529,6 +529,7 @@ class MatrixFactorization:
 
       raterFactors = raterParams.loc[~pd.isna(raterParams[raterFactorName]), raterFactorName]
       propNegativeRaterFactors = (raterFactors < 0).sum() / (raterFactors != 0).sum()
+
       assert propNegativeRaterFactors >= 0.5
 
     return noteParams, raterParams

--- a/sourcecode/scoring/process_data.py
+++ b/sourcecode/scoring/process_data.py
@@ -397,6 +397,21 @@ def filter_ratings(
   return ratings
 
 
+def write_prescoring_output(
+  prescoringNoteModelOutput: pd.DataFrame,
+  prescoringRaterModelOutput: pd.DataFrame,
+  noteModelOutputPath: str,
+  raterModelOutputPath: str,
+):
+  prescoringNoteModelOutput = prescoringNoteModelOutput[c.prescoringNoteModelOutputTSVColumns]
+  assert all(prescoringNoteModelOutput.columns == c.prescoringNoteModelOutputTSVColumns)
+  write_tsv_local(prescoringNoteModelOutput, noteModelOutputPath)
+
+  prescoringRaterModelOutput = prescoringRaterModelOutput[c.prescoringRaterModelOutputTSVColumns]
+  assert all(prescoringRaterModelOutput.columns == c.prescoringRaterModelOutputTSVColumns)
+  write_tsv_local(prescoringRaterModelOutput, raterModelOutputPath)
+
+
 def write_tsv_local(df: pd.DataFrame, path: str) -> None:
   """Write DF as a TSV stored to local disk.
 
@@ -433,6 +448,10 @@ class CommunityNotesDataLoader(ABC):
   def get_data(self) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """Returns notes, ratings, noteStatusHistory, and userEnrollment DataFrames"""
 
+  @abstractmethod
+  def get_prescoring_model_output(self) -> pd.DataFrame:
+    """Returns first round rater model output."""
+
 
 class LocalDataLoader(CommunityNotesDataLoader):
   def __init__(
@@ -444,6 +463,8 @@ class LocalDataLoader(CommunityNotesDataLoader):
     headers: bool,
     shouldFilterNotMisleadingNotes: bool = True,
     logging: bool = True,
+    prescoringNoteModelOutputPath: Optional[str] = None,
+    prescoringRaterModelOutputPath: Optional[str] = None,
   ) -> None:
     """
     Args:
@@ -459,6 +480,8 @@ class LocalDataLoader(CommunityNotesDataLoader):
     self.ratingsPath = ratingsPath
     self.noteStatusHistoryPath = noteStatusHistoryPath
     self.userEnrollmentPath = userEnrollmentPath
+    self.prescoringNoteModelOutputPath = prescoringNoteModelOutputPath
+    self.prescoringRaterModelOutputPath = prescoringRaterModelOutputPath
     self.headers = headers
     self.shouldFilterNotMisleadingNotes = shouldFilterNotMisleadingNotes
     self.logging = logging
@@ -481,3 +504,41 @@ class LocalDataLoader(CommunityNotesDataLoader):
       notes, ratings, noteStatusHistory, self.shouldFilterNotMisleadingNotes, self.logging
     )
     return notes, ratings, noteStatusHistory, userEnrollment
+
+  def get_prescoring_model_output(self) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    print(
+      f"Attempting to read prescoring model output from {self.prescoringNoteModelOutputPath} and {self.prescoringRaterModelOutputPath}"
+    )
+    if self.prescoringRaterModelOutputPath is None:
+      prescoringRaterModelOutput = None
+    else:
+      prescoringRaterModelOutput = tsv_reader(
+        self.prescoringRaterModelOutputPath,
+        c.prescoringRaterModelOutputTSVTypeMapping,
+        c.prescoringRaterModelOutputTSVColumns,
+        header=True,
+      )
+      assert len(prescoringRaterModelOutput.columns) == len(
+        c.prescoringRaterModelOutputTSVColumns
+      ) and all(prescoringRaterModelOutput.columns == c.prescoringRaterModelOutputTSVColumns), (
+        f"Rater model output columns don't match: \n{[col for col in prescoringRaterModelOutput.columns if not col in c.prescoringRaterModelOutputTSVColumns]} are extra columns, "
+        + f"\n{[col for col in c.prescoringRaterModelOutputTSVColumns if not col in prescoringRaterModelOutput.columns]} are missing."
+      )  # ensure constants file is up to date.
+
+    if self.prescoringNoteModelOutputPath is None:
+      prescoringNoteModelOutput = None
+    else:
+      prescoringNoteModelOutput = tsv_reader(
+        self.prescoringNoteModelOutputPath,
+        c.prescoringNoteModelOutputTSVTypeMapping,
+        c.prescoringNoteModelOutputTSVColumns,
+        header=True,
+      )
+      assert len(prescoringNoteModelOutput.columns) == len(
+        c.prescoringNoteModelOutputTSVColumns
+      ) and all(prescoringNoteModelOutput.columns == c.prescoringNoteModelOutputTSVColumns), (
+        f"Note model output columns don't match: \n{[col for col in prescoringNoteModelOutput.columns if not col in c.prescoringNoteModelOutputTSVColumns]} are extra columns, "
+        + f"\n{[col for col in c.prescoringNoteModelOutputTSVColumns if not col in prescoringNoteModelOutput.columns]} are missing."
+      )  # ensure constants file is up to date.
+
+    return prescoringNoteModelOutput, prescoringRaterModelOutput

--- a/sourcecode/scoring/runner.py
+++ b/sourcecode/scoring/runner.py
@@ -3,7 +3,7 @@ import os
 
 from . import constants as c
 from .enums import scorers_from_csv
-from .process_data import LocalDataLoader, write_tsv_local
+from .process_data import LocalDataLoader, write_prescoring_output, write_tsv_local
 from .run_scoring import run_scoring
 
 
@@ -77,6 +77,13 @@ def parse_args():
     dest="parallel",
   )
   parser.set_defaults(parallel=False)
+  parser.add_argument(
+    "--prescoring-delay-hours",
+    default=None,
+    type=int,
+    dest="prescoring_delay_hours",
+    help="Filter prescoring input to simulate delay in hours",
+  )
 
   return parser.parse_args()
 
@@ -89,8 +96,25 @@ def main():
     c.useCurrentTimeInsteadOfEpochMillisForNoteStatusHistory = False
 
   # Load input dataframes.
-  dataLoader = LocalDataLoader(args.notes, args.ratings, args.status, args.enrollment, args.headers)
+  dataLoader = LocalDataLoader(
+    args.notes,
+    args.ratings,
+    args.status,
+    args.enrollment,
+    args.headers,
+    prescoringNoteModelOutputPath=os.path.join(args.outdir, "prescoring_scored_notes.tsv"),
+    prescoringRaterModelOutputPath=os.path.join(args.outdir, "prescoring_helpfulness_scores.tsv"),
+  )
   notes, ratings, statusHistory, userEnrollment = dataLoader.get_data()
+
+  # Prepare callback to write first round scoring output
+  def prescoring_write_fn(notePath, raterPath):
+    return write_prescoring_output(
+      notePath,
+      raterPath,
+      os.path.join(args.outdir, "prescoring_scored_notes.tsv"),
+      os.path.join(args.outdir, "prescoring_helpfulness_scores.tsv"),
+    )
 
   # Invoke scoring and user contribution algorithms.
   scoredNotes, helpfulnessScores, newStatus, auxNoteInfo = run_scoring(
@@ -104,6 +128,8 @@ def main():
     strictColumns=args.strict_columns,
     runParallel=args.parallel,
     dataLoader=dataLoader if args.parallel == True else None,
+    writePrescoringScoringOutputCallback=prescoring_write_fn,
+    filterPrescoringInputToSimulateDelayInHours=args.prescoring_delay_hours,
   )
 
   # Write outputs to local disk.


### PR DESCRIPTION
This PR splits the monolithic scoring binary into two separate scoring binaries (that may still be run sequentially):
1. Prescoring: do expensive pre-computation to learn user and note parameters
2. [Final] Scoring: ingest prescoring outputs in order to save computation time, then run scoring like it is today.

In this commit, the final result of scoring is the same. In the future though, this unlocks much work to simplify the final scorer.