### PR TITLE
Optimize scorer: used shared memory across processes, and streamline uncertainty estimation

### DIFF
--- a/sourcecode/scoring/constants.py
+++ b/sourcecode/scoring/constants.py
@@ -634,6 +634,34 @@ def time_block(label):
 
 
 @dataclass
+class SharedMemoryDataframeInfo:
+  sharedMemoryName: str
+  columns: list
+  dataShape: tuple
+  dtypesDict: dict
+  npDtype: str
+
+
+@dataclass
+class ScoringArgsSharedMemory:
+  noteTopics: SharedMemoryDataframeInfo
+  ratings: SharedMemoryDataframeInfo
+  noteStatusHistory: SharedMemoryDataframeInfo
+  userEnrollment: SharedMemoryDataframeInfo
+
+
+@dataclass
+class PrescoringArgsSharedMemory(ScoringArgsSharedMemory):
+  pass
+
+
+@dataclass
+class FinalScoringArgsSharedMemory(ScoringArgsSharedMemory):
+  prescoringNoteModelOutput: SharedMemoryDataframeInfo
+  prescoringRaterModelOutput: SharedMemoryDataframeInfo
+
+
+@dataclass
 class ScoringArgs:
   noteTopics: pd.DataFrame
   ratings: pd.DataFrame
@@ -641,6 +669,7 @@ class ScoringArgs:
   userEnrollment: pd.DataFrame
 
   def remove_large_args_for_multiprocessing(self):
+    self.noteTopics = None
     self.ratings = None
     self.noteStatusHistory = None
     self.userEnrollment = None

--- a/sourcecode/scoring/helpfulness_scores.py
+++ b/sourcecode/scoring/helpfulness_scores.py
@@ -190,7 +190,7 @@ def filter_ratings_by_helpfulness_scores(
       filtered_ratings pandas.DataFrame: same schema as input ratings, but filtered.
   """
   includedUsers = helpfulnessScores.loc[
-    helpfulnessScores[c.aboveHelpfulnessThresholdKey], [c.raterParticipantIdKey]
+    helpfulnessScores[c.aboveHelpfulnessThresholdKey].fillna(False), [c.raterParticipantIdKey]
   ]
   ratingsHelpfulnessScoreFiltered = includedUsers.merge(
     ratingsForTraining, on=c.raterParticipantIdKey

--- a/sourcecode/scoring/matrix_factorization/pseudo_raters.py
+++ b/sourcecode/scoring/matrix_factorization/pseudo_raters.py
@@ -85,15 +85,13 @@ class PseudoRatersRunner:
     assert (noteParamsFromNewModel == self.noteParams).all().all()
 
   def _make_extreme_raters(self, raterParams: pd.DataFrame, raterIdMap: pd.DataFrame):
-    """Populates self.extremeRaters, which is a list of dicts with rater id info
+    """Populates self.extremeRaters, which is a list of dicts with rater id info"""
 
-    Args:
-        raterParams (_type_): _description_
-        raterIdMap (_type_): _description_
-    """
+    # Because LCB is turned off and we therefore don't use not-helpful pseudoratings anymore,
+    # we only include the min rater intercept (which produces the highest possible note intercept)
+    # If we were to use not-helpful pseudoratings, we would also include the max rater intercept.
     raterInterceptValues = [
       raterParams[c.internalRaterInterceptKey].min(),
-      raterParams[c.internalRaterInterceptKey].max(),
     ]
     raterFactorValues = [
       raterParams[c.internalRaterFactor1Key].min(),
@@ -211,7 +209,8 @@ class PseudoRatersRunner:
     for extremeRater in self.extremeRaters:
       extremeRater[c.raterParticipantIdKey] = str(extremeRater[c.raterParticipantIdKey])
 
-      for helpfulNum in (0.0, 1.0):
+      # Since LCB is turned off, don't waste compute on not-helpful pseudoratings.
+      for helpfulNum in [1.0]:  # Only helpful ratings
         extremeRater[c.helpfulNumKey] = helpfulNum
         self.extremeRatingsToAddWithoutNotes.append(extremeRater.copy())
 


### PR DESCRIPTION
1. Final scoring and prescoring each run about ~10mins faster now when run in parallel on one large CPU machine, due to sharing large dataframes in memory across multiple processes instead of re-reading them.

2. Also, the core scorer itself now runs about ~10mins faster due to cleanup of unused pseudorater computations (uncertainty estimation)