### PR TITLE
Refactoring, global expansion modeling updates, and post selection values

### DIFF
--- a/sourcecode/scoring/incorrect_filter.py
+++ b/sourcecode/scoring/incorrect_filter.py
@@ -8,49 +8,60 @@ import numpy as np
 import pandas as pd
 
 
-def _get_user_incorrect_ratio(nhTagRatings: pd.DataFrame) -> pd.DataFrame:
+def get_user_incorrect_ratio(ratings: pd.DataFrame) -> pd.DataFrame:
   """Computes empirical p(incorrect | not helpful tags assigned) per rater.
+  Called during prescoring only, since it uses entire rating history.
 
   Args:
-    nhTagRatings: DF containing all ratings with some NH tag
+    ratings: DF containing ratings.
 
   Returns:
     pd.DataFrame containing one row per user who assigned not helpful tags with their empirical propensity
     to assign "incorrect" tag
   """
+  # Filter down to just ratings with some nh tags used.
+  nhTagRatings = ratings.loc[ratings[c.notHelpfulTagsTSVOrder].sum(axis=1) > 0]
 
   user_incorrect = (
-    nhTagRatings[[c.raterParticipantIdKey, c.notHelpfulIncorrectTagKey]]
-    .groupby(c.raterParticipantIdKey)
-    .agg("sum")
+    (
+      nhTagRatings[[c.raterParticipantIdKey, c.notHelpfulIncorrectTagKey]]
+      .groupby(c.raterParticipantIdKey)
+      .agg("sum")
+    )
+    .rename(columns={c.notHelpfulIncorrectTagKey: c.incorrectTagRatingsMadeByRaterKey})
+    .reset_index()
   )
+
   user_nh_rating_count = (
-    nhTagRatings[[c.raterParticipantIdKey, c.noteIdKey]]
-    .groupby(c.raterParticipantIdKey)
-    .agg("count")
+    (
+      nhTagRatings[[c.raterParticipantIdKey, c.noteIdKey]]
+      .groupby(c.raterParticipantIdKey)
+      .agg("count")
+    )
+    .rename(columns={c.noteIdKey: c.totalRatingsMadeByRaterKey})
+    .reset_index()
   )
-  user_nh_rating_count.rename(columns={c.noteIdKey: "cnt"}, inplace=True)
+
   user_totals = user_incorrect.merge(user_nh_rating_count, on=c.raterParticipantIdKey)
 
   return user_totals
 
 
 def _get_incorrect_tfidf_ratio(
-  augmented_ratings: pd.DataFrame, user_filter: Optional[bool], suffix: str
+  augmented_ratings: pd.DataFrame, interval_filter: Optional[bool]
 ) -> pd.DataFrame:
   """Computes empirical p(incorrect | note) / p(incorrect | raters over all notes) subject to rater-note inclusion function.
 
   Args:
     augmented_ratings: ratings DF with note and rater factors and user incorrect TF
-    filter: inclusion criteria for "incorrect" voters
-    suffix: suffix for incorrect and count column names for this filter
+    interval_filter: inclusion criteria: only keep the ratings where the rater and note factors are within a certain interval
 
   Returns:
     pd.DataFrame with one row for each note, with computed sum(tf_idf_incorrect) score for raters
     included in filter
   """
-  if user_filter is not None:
-    ratings_w_user_totals = augmented_ratings[user_filter]
+  if interval_filter is not None:
+    ratings_w_user_totals = augmented_ratings[interval_filter]
   else:
     ratings_w_user_totals = augmented_ratings
 
@@ -60,7 +71,7 @@ def _get_incorrect_tfidf_ratio(
     .agg("count")
     .reset_index()
   )
-  note_nh_count.rename(columns={c.raterParticipantIdKey: "num_voters"}, inplace=True)
+  note_nh_count.rename(columns={c.raterParticipantIdKey: c.numVotersKey}, inplace=True)
 
   columns_to_attempt_to_drop = [
     c.internalRaterFactor1Key,
@@ -70,34 +81,47 @@ def _get_incorrect_tfidf_ratio(
   columns_to_drop = ratings_w_user_totals.columns.intersection(columns_to_attempt_to_drop)
   ratings_w_user_totals.drop(columns_to_drop, inplace=True, axis=1)
 
-  ratings_w_user_totals["p_incorrect_user"] = (
-    ratings_w_user_totals["notHelpfulIncorrect_total"] / ratings_w_user_totals["cnt"]
+  ratings_w_user_totals[c.incorrectTagRateByRaterKey] = (
+    ratings_w_user_totals[c.incorrectTagRatingsMadeByRaterKey]
+    / ratings_w_user_totals[c.totalRatingsMadeByRaterKey]
   )
 
   rating_aggs = ratings_w_user_totals.groupby(c.noteIdKey).agg("sum").reset_index()
   rating_aggs_w_cnt = rating_aggs.merge(note_nh_count, on=c.noteIdKey)
 
-  rating_aggs_w_cnt["tf_idf_incorrect"] = (rating_aggs_w_cnt[c.notHelpfulIncorrectTagKey]) / np.log(
-    1 + (rating_aggs_w_cnt["p_incorrect_user"])
+  rating_aggs_w_cnt[c.noteTfIdfIncorrectScoreKey] = (
+    rating_aggs_w_cnt[c.notHelpfulIncorrectTagKey]
+  ) / np.log(
+    1 + (rating_aggs_w_cnt[c.incorrectTagRateByRaterKey])
   )  # p(incorrect over all rater ratings)
-  rating_aggs_w_cnt.drop(["notHelpfulIncorrect_total", "cnt"], inplace=True, axis=1)
-  rating_aggs_w_cnt.columns = [c.noteIdKey] + [
-    f"{col}{suffix}" for col in rating_aggs_w_cnt.columns[1:]
-  ]
+  rating_aggs_w_cnt.drop(
+    [c.totalRatingsMadeByRaterKey, c.incorrectTagRatingsMadeByRaterKey], inplace=True, axis=1
+  )
+
+  rating_aggs_w_cnt.rename(
+    columns={
+      c.notHelpfulIncorrectTagKey: c.notHelpfulIncorrectIntervalKey,
+      c.incorrectTagRateByRaterKey: c.sumOfIncorrectTagRateByRaterIntervalKey,
+      c.numVotersKey: c.numVotersIntervalKey,
+      c.noteTfIdfIncorrectScoreKey: c.noteTfIdfIncorrectScoreIntervalKey,
+    },
+    inplace=True,
+  )
   return rating_aggs_w_cnt
 
 
-def get_incorrect_aggregates(
+def get_incorrect_aggregates_final_scoring(
   ratings: pd.DataFrame,
   noteParams: pd.DataFrame,
-  raterParams: pd.DataFrame,
+  raterParamsWithRatingCounts: pd.DataFrame,
 ) -> pd.DataFrame:
-  """Computes non-helpful tag aggregates for each note.
+  """Computes non-helpful tag aggregates for each note. Intended to be called in final scoring.
 
   Args:
     ratings: initial input ratings DF containing all ratings
     noteParams: MF results for notes
-    raterParams: MF results for raters
+    raterParamsWithRatingCounts: MF results for raters. Should include c.incorrectTagRatingsMadeByRaterKey and c.totalRatingsMadeByRaterKey.
+    raterIncorrectTagRatingCounts: should contain: c.raterParticipantIdKey,
 
   Returns:
     pd.DataFrame containing one row per note that was scored during MF.  Columns correspond to
@@ -107,18 +131,24 @@ def get_incorrect_aggregates(
   # consider only ratings with some NH tag
   notHelpfulTaggedRatings = ratings.loc[ratings[c.notHelpfulTagsTSVOrder].sum(axis=1) > 0]
 
-  # get per user incorrect term frequency
-  user_totals = _get_user_incorrect_ratio(notHelpfulTaggedRatings)
-  # add user and note factors
+  # join user totals, note factors, and rater factors with each rating
   ratings_w_user_totals = (
     notHelpfulTaggedRatings[[c.raterParticipantIdKey, c.noteIdKey, c.notHelpfulIncorrectTagKey]]
-    .merge(user_totals, on=c.raterParticipantIdKey, suffixes=(None, "_total"))
     .merge(noteParams[[c.noteIdKey, c.internalNoteFactor1Key]], on=c.noteIdKey)
     .merge(
-      raterParams[[c.raterParticipantIdKey, c.internalRaterFactor1Key]], on=c.raterParticipantIdKey
+      raterParamsWithRatingCounts[
+        [
+          c.raterParticipantIdKey,
+          c.internalRaterFactor1Key,
+          c.incorrectTagRatingsMadeByRaterKey,
+          c.totalRatingsMadeByRaterKey,
+        ]
+      ],
+      on=c.raterParticipantIdKey,
     )
   )
 
+  # Keep users with clipped factors within a certain interval of notes' (e.g. within 0.3)
   interval_filter = (
     np.abs(
       ratings_w_user_totals[c.internalRaterFactor1Key].clip(-0.4, 0.4)
@@ -127,7 +157,20 @@ def get_incorrect_aggregates(
     < c.intervalHalfWidth
   )
 
-  incorrectAggregates = _get_incorrect_tfidf_ratio(
-    ratings_w_user_totals, interval_filter, "_interval"
-  )
+  incorrectAggregates = _get_incorrect_tfidf_ratio(ratings_w_user_totals, interval_filter)
   return incorrectAggregates
+
+
+def get_incorrect_aggregates(
+  ratings: pd.DataFrame,
+  noteParams: pd.DataFrame,
+  raterParams: pd.DataFrame,
+) -> pd.DataFrame:
+  """
+  Legacy version of this function, computable all at once instead of being called separately in prescoring
+  vs. final scoring.
+  """
+  # get per user incorrect term frequency -- normally called during prescoring
+  raterParamsWithRatingCounts = raterParams.merge(get_user_incorrect_ratio(ratings))
+
+  return get_incorrect_aggregates_final_scoring(ratings, noteParams, raterParamsWithRatingCounts)

--- a/sourcecode/scoring/note_ratings.py
+++ b/sourcecode/scoring/note_ratings.py
@@ -460,7 +460,7 @@ def compute_scored_notes(
       assert len(tagAggregates) == len(noteParams), "there should be one aggregate per scored note"
       noteStats = tagAggregates.merge(noteStats, on=c.noteIdKey, how="outer")
     with c.time_block("compute_scored_notes: compute incorrect aggregates"):
-      incorrectAggregates = incorrect_filter.get_incorrect_aggregates(
+      incorrectAggregates = incorrect_filter.get_incorrect_aggregates_final_scoring(
         ratings, noteParams, raterParams
       )
       noteStats = noteStats.merge(incorrectAggregates, on=c.noteIdKey, how="outer")

--- a/sourcecode/scoring/post_selection_similarity.py
+++ b/sourcecode/scoring/post_selection_similarity.py
@@ -1,0 +1,215 @@
+from typing import Dict
+
+from . import constants as c
+
+import numpy as np
+import pandas as pd
+
+
+class PostSelectionSimilarity:
+  def __init__(
+    self,
+    notes: pd.DataFrame,
+    ratings: pd.DataFrame,
+    pmiRegularization: int = 500,
+    smoothedNpmiThreshold: float = 0.60,
+  ):
+    self.ratings = _preprocess_ratings(notes, ratings)
+    self.pairCounts = _get_pair_counts(self.ratings)
+    self.pairStatsDf = _make_rater_stats_df(self.pairCounts)
+    self.uniqueRatingsOnTweets = self.ratings[
+      [c.tweetIdKey, c.raterParticipantIdKey]
+    ].drop_duplicates()
+    self.pairStatsDf = _join_rater_totals(self.pairStatsDf, self.uniqueRatingsOnTweets)
+    self.pmiDf = _compute_pmi(self.pairStatsDf, len(self.uniqueRatingsOnTweets), pmiRegularization)
+
+    self.filter_edges_below_threshold(smoothedNpmiThreshold)
+
+  def filter_edges_below_threshold(self, smoothedNpmiThreshold: float = 0.6):
+    graphDf = self.pmiDf[["leftRaterId", "rightRaterId", "smoothedNpmi"]]
+    graphDf.columns = ["source", "target", "weight"]
+    self.graphDf = graphDf[graphDf["weight"] >= smoothedNpmiThreshold]
+
+  def get_high_post_selection_similarity_raters(self):
+    highPostSelectionSimilarityRaters = pd.concat(
+      [
+        self.graphDf[["source"]].rename(columns={"source": c.raterParticipantIdKey}),
+        self.graphDf[["target"]].rename(columns={"target": c.raterParticipantIdKey}),
+      ]
+    ).drop_duplicates()
+    highPostSelectionSimilarityRaters[c.postSelectionValueKey] = 1
+    return highPostSelectionSimilarityRaters
+
+  def get_post_selection_similarity_values(self):
+    """
+    Returns dataframe with [raterParticipantId, postSelectionSimilarityValue] columns.
+    postSelectionSimilarityValue is None by default.
+    """
+    cliqueToUserMap, userToCliqueMap = aggregate_into_cliques(self.graphDf)
+
+    # Convert dict to pandas dataframe
+    cliquesDfList = []
+    for cliqueId in cliqueToUserMap.keys():
+      for userId in cliqueToUserMap[cliqueId]:
+        cliquesDfList.append({c.raterParticipantIdKey: userId, c.postSelectionValueKey: cliqueId})
+    cliquesDf = pd.DataFrame(
+      cliquesDfList, columns=[c.raterParticipantIdKey, c.postSelectionValueKey]
+    )
+    return cliquesDf
+
+
+def filter_ratings_by_post_selection_similarity(ratings, highPostSelectionSimilarityRaters):
+  """
+  Filters out ratings from raters who have high post selection similarity.
+  """
+  ratings = ratings.merge(
+    highPostSelectionSimilarityRaters, on=c.raterParticipantIdKey, how="left", indicator=True
+  )
+  ratings = ratings[ratings["_merge"] == "left_only"]
+  ratings = ratings.drop(columns=["_merge"])
+  return ratings
+
+
+def _compute_pmi(pairStatsDf: pd.DataFrame, N: int, pmiPseudocounts: int = 500) -> pd.DataFrame:
+  """
+  Compute PMI between raters.
+  """
+  numerator = pairStatsDf["pairRatings"] * N
+  denominator = (pairStatsDf["leftTotal"] + pmiPseudocounts) * (
+    pairStatsDf["rightTotal"] + pmiPseudocounts
+  )
+  pairStatsDf["smoothedPmi"] = np.log(numerator / denominator)
+  pairStatsDf["smoothedNpmi"] = pairStatsDf["smoothedPmi"] / -np.log(pairStatsDf["pairRatings"] / N)
+  pairStatsDf["minSim"] = pairStatsDf["pairRatings"] / np.minimum(
+    pairStatsDf["leftTotal"], pairStatsDf["rightTotal"]
+  )
+  return pairStatsDf
+
+
+def _preprocess_ratings(notes: pd.DataFrame, ratings: pd.DataFrame) -> pd.DataFrame:
+  """
+  Preprocess ratings dataframe.
+  """
+  ratings = notes[[c.noteIdKey, c.tweetIdKey]].merge(
+    ratings[[c.raterParticipantIdKey, c.noteIdKey, c.createdAtMillisKey]],
+    on=c.noteIdKey,
+    how="inner",
+  )
+  ratings = ratings[(ratings[c.tweetIdKey] != -1) & (ratings[c.tweetIdKey] != "-1")]
+  return ratings
+
+
+def _join_rater_totals(
+  pairStatsDf: pd.DataFrame, uniqueRatingsOnTweets: pd.DataFrame, minRatings: int = 10
+):
+  raterTotals = uniqueRatingsOnTweets[c.raterParticipantIdKey].value_counts().reset_index()
+  raterTotals.columns = [c.raterParticipantIdKey, "count"]
+  raterTotals = raterTotals[raterTotals["count"] >= minRatings]
+  pairStatsDf = pairStatsDf.merge(
+    raterTotals.rename(columns={c.raterParticipantIdKey: "leftRaterId", "count": "leftTotal"})
+  )
+  pairStatsDf = pairStatsDf.merge(
+    raterTotals.rename(columns={c.raterParticipantIdKey: "rightRaterId", "count": "rightTotal"})
+  )
+  return pairStatsDf
+
+
+def aggregate_into_cliques(graphDf):
+  with c.time_block("Aggregate into cliques by post selection similarity"):
+    userToCliqueMap = dict()
+    cliqueToUserMap = dict()
+
+    nextNewCliqueId = 1  # start cliqueIdxs from 1
+    for i, row in graphDf.iterrows():
+      sid = row["source"]
+      tid = row["target"]
+      if sid in userToCliqueMap:
+        if tid in userToCliqueMap:
+          # both in map. merge if not same clique
+          if userToCliqueMap[sid] != userToCliqueMap[tid]:
+            # merge. assign all member's of target clique to source clique.
+            # slow way: iterate over all values here.
+            # fast way: maintain a reverse map of cliqueToUserMap.
+            sourceDestClique = userToCliqueMap[sid]
+            oldTargetCliqueToDel = userToCliqueMap[tid]
+
+            for userId in cliqueToUserMap[oldTargetCliqueToDel]:
+              cliqueToUserMap[sourceDestClique].append(userId)
+              userToCliqueMap[userId] = sourceDestClique
+            del cliqueToUserMap[oldTargetCliqueToDel]
+
+        else:
+          # source in map; target not. add target to source's clique
+          sourceClique = userToCliqueMap[sid]
+          userToCliqueMap[tid] = sourceClique
+          cliqueToUserMap[sourceClique].append(tid)
+      elif tid in userToCliqueMap:
+        # target in map; source not. add source to target's clique
+        targetClique = userToCliqueMap[tid]
+        userToCliqueMap[sid] = targetClique
+        cliqueToUserMap[targetClique].append(sid)
+      else:
+        # new clique
+        userToCliqueMap[sid] = nextNewCliqueId
+        userToCliqueMap[tid] = nextNewCliqueId
+        cliqueToUserMap[nextNewCliqueId] = [sid, tid]
+        nextNewCliqueId += 1
+  return cliqueToUserMap, userToCliqueMap
+
+
+def _make_rater_stats_df(pairCounts):
+  with c.time_block("Making rater stats dataframe from pair counts dict"):
+    leftRater, rightRater, pairRatings = [], [], []
+    for i, ((left, right), count) in enumerate(pairCounts.items()):
+      leftRater.append(left)
+      rightRater.append(right)
+      pairRatings.append(count)
+  return pd.DataFrame(
+    {
+      "leftRaterId": np.array(leftRater),
+      "rightRaterId": np.array(rightRater),
+      "pairRatings": np.array(pairRatings),
+    }
+  )
+
+
+def _get_pair_counts(ratings: pd.DataFrame, windowMillis: int = 1000 * 60 * 10) -> Dict:
+  """
+  Compute counts of unique posts that were co-rated within windowMillis millis of each other
+  by different users.
+
+  Returns dict: (raterId1, raterId2) => count.
+  """
+  with c.time_block("Computing rating pair counts"):
+    counts = dict()
+    seen = set()
+    ratings = ratings.sort_values([c.noteIdKey, c.createdAtMillisKey])
+    values = ratings[
+      [c.noteIdKey, c.createdAtMillisKey, c.raterParticipantIdKey, c.tweetIdKey]
+    ].values
+    print(len(values))
+    for i in range(len(values)):
+      priorNote, priorTs, priorRater, priorTweet = values[i]
+      if i == 0 or i == 1000 or i == 100000 or i % 5000000 == 0:
+        print(f"get_pair_counts i={i}")
+      j = i + 1
+      while j < len(values):
+        nextNote, nextTs, nextRater, nextTweet = values[j]
+        assert priorNote <= nextNote, (priorNote, nextNote)
+        if nextNote != priorNote:
+          break  # break if we're onto a new note
+        assert priorTweet == nextTweet, (priorTweet, nextTweet)  # tweet should be same
+        assert priorRater != nextRater, (priorRater, nextRater)  # rater should be different
+        assert priorTs <= nextTs, (priorTs, nextTs)
+        if nextTs > (priorTs + windowMillis):
+          break  # break if we're beyond windowMillis
+        raterPairKey = tuple(sorted((priorRater, nextRater)))
+        raterTweetPairKey = (raterPairKey, priorTweet)
+        if raterTweetPairKey in seen:
+          break  # break if we already counted a match on this tweet
+        seen.add(raterTweetPairKey)
+        if raterPairKey not in counts:
+          counts[raterPairKey] = 0
+        counts[raterPairKey] += 1
+        j += 1
+    return counts

--- a/sourcecode/scoring/runner.py
+++ b/sourcecode/scoring/runner.py
@@ -82,19 +82,42 @@ def parse_args():
     dest="parallel",
   )
   parser.set_defaults(parallel=False)
-  parser.add_argument(
-    "--prescoring-delay-hours",
-    default=None,
-    type=int,
-    dest="prescoring_delay_hours",
-    help="Filter prescoring input to simulate delay in hours",
-  )
+
   parser.add_argument(
     "--no-parquet",
     help="Disable writing parquet files.",
     default=False,
     action="store_true",
     dest="no_parquet",
+  )
+
+  parser.add_argument(
+    "--cutoff-timestamp-millis",
+    default=None,
+    type=int,
+    dest="cutoffTimestampMillis",
+    help="filter notes and ratings created after this time.",
+  )
+  parser.add_argument(
+    "--exclude-ratings-after-a-note-got-first-status-plus-n-hours",
+    default=None,
+    type=int,
+    dest="excludeRatingsAfterANoteGotFirstStatusPlusNHours",
+    help="Exclude ratings after a note got first status plus n hours",
+  )
+  parser.add_argument(
+    "--days-in-past-to-apply-post-first-status-filtering",
+    default=14,
+    type=int,
+    dest="daysInPastToApplyPostFirstStatusFiltering",
+    help="Days in past to apply post first status filtering",
+  )
+  parser.add_argument(
+    "--prescoring-delay-hours",
+    default=None,
+    type=int,
+    dest="prescoring_delay_hours",
+    help="Filter prescoring input to simulate delay in hours",
   )
 
   return parser.parse_args()
@@ -151,6 +174,9 @@ def main():
     runParallel=args.parallel,
     dataLoader=dataLoader if args.parallel == True else None,
     writePrescoringScoringOutputCallback=prescoring_write_fn,
+    cutoffTimestampMillis=args.cutoffTimestampMillis,
+    excludeRatingsAfterANoteGotFirstStatusPlusNHours=args.excludeRatingsAfterANoteGotFirstStatusPlusNHours,
+    daysInPastToApplyPostFirstStatusFiltering=args.daysInPastToApplyPostFirstStatusFiltering,
     filterPrescoringInputToSimulateDelayInHours=args.prescoring_delay_hours,
   )
 


### PR DESCRIPTION
-Add note status change dataset definition to constants.py 
-Split incorrect tag filtering between prescoring and final scoring (compute user aggregates in prescoring) as part of streamlining final scoring 
-Compute post selection values using pmi, and treat as component of reputation 
-Ignore note authorship when assigning a note to a model e.g. expansion; only consider ratings. Assign a note to expansion model if >50% of its ratings are from expansion raters. 
-Add data filtering arguments for easier testing.