### PR TITLE
Tb/interest documentation update

### DIFF
--- a/documentation/under-the-hood/helpful-notes.md
+++ b/documentation/under-the-hood/helpful-notes.md
@@ -1,0 +1,25 @@
+---
+title: Follow @HelpfulNotes
+description: How to follow Community Notes that people are finding helpful
+navWeight: 3
+---
+# Follow @HelpfulNotes
+
+Want to keep up-to-date with the Community Notes that people are finding helpful? These notes have always been [public](download-data.md), and you can follow them on various “Helpful Notes” accounts:
+
+- Dutch/Nederlands - [@NuttigeOpm](http://x.com/NuttigeOpm)
+- English - [@HelpfulNotes](http://x.com/HelpfulNotes)
+- French/français - [@NotesUtiles](http://x.com/NotesUtiles)
+- German/Deutsch - [@HilfrchAnmerkg](http://x.com/HilfrchAnmerkg)
+- Italian/italiano - [@NoteUtili](http://x.com/NoteUtili)
+- Japanese/日本語 - [@HelpfulNotesJP](http://x.com/HelpfulNotesJP)
+- Portuguese/português - [@NotasUteis](http://x.com/NotasUteis)
+- Spanish/español - [@NotasUtilesES](http://x.com/NotasUtilesES)
+
+### How it works
+
+These accounts automatically repost Community Notes that meet the following criteria:
+- Have been rated Helpful by contributors
+- Have kept their status of Helpful for 6hr+
+- Have a high helpfulness score (0.45+ intercept score)
+- If the note contains terms that contributors have reported as sometimes overwhelming the Helpful Notes timelines ("spam", "scam", "dropship", "drop ship", "promotion") it will have a lower probability of appearing, so as to avoid overwhelming the timeline. This is experimental to determine if it improves follower satisfaction.

--- a/documentation/under-the-hood/timeline-tabs.md
+++ b/documentation/under-the-hood/timeline-tabs.md
@@ -47,6 +47,7 @@ A variety of criteria are considered when determining whether to include a note,
 - Current status (e.g. "Needs More Ratings")
 - Current helpfulness score (e.g. not a low helpfulness score, highly rated by initial raters, possibly nearing the threshold to earn status of "Helpful")
 - Does not have a large number of ratings (such that more ratings could change the note's status)
+- If the note contains terms that contributors have reported as sometimes overwhelming the Needs Your Help tab ("spam", "scam", "dropship", "drop ship", "promotion") it will have a lower probability of appearing, so as to avoid overwhelming the tab. This is experimental to determine if it improves contributor satisfaction.
 
 In this case of alerts, notifications are sent to a random selection of contributors, excluding the note author and those who have already rated the note. Notifications are also limited by the recipient's notification frequency setting.
 


### PR DESCRIPTION
Add documentation for Helpful Notes accounts, and new probabilistic criteria for NYH and Helpful Notes feeds to address contributor and follower feedback about some notes overwhelming those feeds.