### PR TITLE
Multiple behind-the-scenes changes (split scorer into smaller/faster chunks; versions++ & typing improvements).

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ cd sourcecode
 $ python main.py
 ```
 
-Most versions of Python3 should work, but we have tested the code with Python 3.8.
+Multiple versions of Python3 should work, but we have tested the code with Python 3.10.
 
 ### Community Notes data
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.26.2
-pandas==2.1.4
+numpy==1.26.4
+pandas==2.2.2
 torch==2.1.2
 scipy==1.11.4
-scikit-learn>=1.3.0
+scikit-learn==1.3.0
 pyarrow

--- a/sourcecode/scoring/incorrect_filter.py
+++ b/sourcecode/scoring/incorrect_filter.py
@@ -86,6 +86,20 @@ def _get_incorrect_tfidf_ratio(
     / ratings_w_user_totals[c.totalRatingsMadeByRaterKey]
   )
 
+  # Setup columns to be aggregated so they are not dropped during aggregation
+  ratings_w_user_totals[c.incorrectTagRateByRaterKey].fillna(0, inplace=True)
+  ratings_w_user_totals[c.incorrectTagRateByRaterKey] = ratings_w_user_totals[
+    c.incorrectTagRateByRaterKey
+  ].astype(np.double)
+  ratings_w_user_totals[c.incorrectTagRatingsMadeByRaterKey].fillna(0, inplace=True)
+  ratings_w_user_totals[c.incorrectTagRatingsMadeByRaterKey] = ratings_w_user_totals[
+    c.incorrectTagRatingsMadeByRaterKey
+  ].astype(np.double)
+  ratings_w_user_totals[c.totalRatingsMadeByRaterKey].fillna(0, inplace=True)
+  ratings_w_user_totals[c.totalRatingsMadeByRaterKey] = ratings_w_user_totals[
+    c.totalRatingsMadeByRaterKey
+  ].astype(np.double)
+
   rating_aggs = ratings_w_user_totals.groupby(c.noteIdKey).agg("sum").reset_index()
   rating_aggs_w_cnt = rating_aggs.merge(note_nh_count, on=c.noteIdKey)
 

--- a/sourcecode/scoring/matrix_factorization/pseudo_raters.py
+++ b/sourcecode/scoring/matrix_factorization/pseudo_raters.py
@@ -136,7 +136,8 @@ class PseudoRatersRunner:
                 mf_c.raterIndexKey: [raterDict[mf_c.raterIndexKey]],
               }
             ),
-          ]
+          ],
+          unsafeAllowed=c.raterParticipantIdKey,
         )
 
       if not (
@@ -152,7 +153,12 @@ class PseudoRatersRunner:
                 c.internalRaterFactor1Key: [raterDict[c.internalRaterFactor1Key]],
               }
             ),
-          ]
+          ],
+          unsafeAllowed={
+            c.raterParticipantIdKey,
+            c.internalRaterInterceptKey,
+            c.internalRaterFactor1Key,
+          },
         )
 
   def _create_new_model_with_extreme_raters_from_original_params(
@@ -264,7 +270,14 @@ class PseudoRatersRunner:
     return noteParamsList
 
   def _aggregate_note_params(self, noteParamsList, joinOrig=False):
-    rawRescoredNotesWithEachExtraRater = pd.concat(noteParamsList)
+    rawRescoredNotesWithEachExtraRater = pd.concat(
+      noteParamsList,
+      unsafeAllowed={
+        Constants.extraRaterInterceptKey,
+        Constants.extraRaterFactor1Key,
+        Constants.extraRatingHelpfulNumKey,
+      },
+    )
     rawRescoredNotesWithEachExtraRater.drop(mf_c.noteIndexKey, axis=1, inplace=True)
     rawRescoredNotesWithEachExtraRater = rawRescoredNotesWithEachExtraRater.sort_values(
       by=[c.noteIdKey, Constants.extraRaterInterceptKey]

--- a/sourcecode/scoring/mf_core_scorer.py
+++ b/sourcecode/scoring/mf_core_scorer.py
@@ -65,6 +65,7 @@ def filter_core_output(
     userGroups.rename(columns={c.participantIdKey: c.raterParticipantIdKey}),
     on=c.raterParticipantIdKey,
     how="left",
+    unsafeAllowed=_CORE_BOOL,
   )
   print(f"  Final ratings length: {len(ratings)}")
   ratings = ratings.fillna({_CORE_BOOL: True})

--- a/sourcecode/scoring/mf_expansion_scorer.py
+++ b/sourcecode/scoring/mf_expansion_scorer.py
@@ -163,6 +163,7 @@ class MFExpansionScorer(MFBaseScorer):
       userGroups.rename(columns={c.participantIdKey: c.raterParticipantIdKey}),
       on=c.raterParticipantIdKey,
       how="left",
+      unsafeAllowed=_EXPANSION_BOOL,
     )
     print(f"  Final ratings length: {len(ratings)}")
     ratings = ratings.fillna({_EXPANSION_BOOL: True})

--- a/sourcecode/scoring/mf_group_scorer.py
+++ b/sourcecode/scoring/mf_group_scorer.py
@@ -20,22 +20,13 @@ _groupScorerParalleism = {
 }
 
 
-def coalesce_group_models(
-  scoredNotes: pd.DataFrame, helpfulnessScores: pd.DataFrame
-) -> Tuple[pd.DataFrame, pd.DataFrame]:
-  """Coalesce all group modeling columns across note and user scoring.
+def coalesce_group_model_scored_notes(scoredNotes: pd.DataFrame) -> pd.DataFrame:
+  """Coalesce all group modeling columns across note scoring.
 
   Since each Scorer must have distinct output columns, we use coalescing to run
   multiple instances of MFGroupScorer objects and then condense the results into
   a single set of columns.  This approach works because each note will be scored
   by at most one MFGroupScorer instance.
-
-  Args:
-    scoredNotes: scoring output for notes.
-    helpfulnessScores: scoring output for users.
-
-  Returns:
-    tuple containing coalesced scoring results for notes and users.
   """
   for col in [
     c.groupNoteInterceptKey,
@@ -49,10 +40,20 @@ def coalesce_group_models(
   ]:
     scoredNotes = coalesce_columns(scoredNotes, col)
 
+  return scoredNotes
+
+
+def coalesce_group_model_helpfulness_scores(helpfulnessScores: pd.DataFrame) -> pd.DataFrame:
+  """Coalesce all group modeling columns across user scoring.
+
+  Since each Scorer must have distinct output columns, we use coalescing to run
+  multiple instances of MFGroupScorer objects and then condense the results into
+  a single set of columns.  This approach works because each note will be scored
+  by at most one MFGroupScorer instance.
+  """
   for col in [c.groupRaterInterceptKey, c.groupRaterFactor1Key, c.modelingGroupKey]:
     helpfulnessScores = coalesce_columns(helpfulnessScores, col)
-
-  return scoredNotes, helpfulnessScores
+  return helpfulnessScores
 
 
 class MFGroupScorer(MFBaseScorer):

--- a/sourcecode/scoring/mf_topic_scorer.py
+++ b/sourcecode/scoring/mf_topic_scorer.py
@@ -255,6 +255,8 @@ class MFTopicScorer(MFBaseScorer):
     negFactorCounts = negFactorCounts[negFactorCounts["negRatingTotal"] > 4][[c.noteIdKey]]
     confidentNotes = posFactorCounts.merge(negFactorCounts)
     confidentNotes[self._noteTopicConfidentKey] = True
-    noteScores = noteScores.merge(confidentNotes, how="left")
+    noteScores = noteScores.merge(
+      confidentNotes, how="left", unsafeAllowed=[self._noteTopicConfidentKey, c.defaultIndexKey]
+    )
     noteScores = noteScores.fillna({self._noteTopicConfidentKey: False})
     return noteScores, userScores

--- a/sourcecode/scoring/pandas_utils.py
+++ b/sourcecode/scoring/pandas_utils.py
@@ -1,0 +1,490 @@
+"""This module patches Pandas to alert or fail on unexpected dtype conversions.
+
+The module corrently supports the merge, join and concat operations as these functions
+can generate derived dataframes with type conversions.  The patch can be configured to
+either log to stderr or assert False when an unexpected type conversion is detected.
+
+This module should support type-related work in the scorer, including:
+* Setting all input datatypes to the appropriate np (non-nullable) or pd (nullable) datatype
+  for the associated input.  For example, noteIds should be np.int64, timestamp of first
+  status should be pd.Int64Dtype, etc.
+* Enforcing type expectations on outputs.  For example, validating that the participantId
+  is an int64 and has not been converted to float.
+* Fixing unexpected type conversion errors by specifying default values for rows that are
+  lacking columns during a merge, join or concat.  For example, if we generate numRatings
+  and then join with noteStatusHistory, we should be able to pass fillna={"numRatings": 0}
+  to "merge" so that the resulting column should still have type np.int64 where missing
+  values have been filled with 0 (as opposed to cast to a float with missing values set to
+  np.NaN).
+* Add an "allow_unsafe" keyword argument to merge, join and concat that overrides "fail"
+  and instead logs to stderr.  This will allow us to default all current and new code to
+  enforced safe behavior except for callsites that haven't been fixed yet.
+"""
+
+from collections import Counter
+import sys
+from threading import Lock
+import traceback
+from typing import Any, Callable, Dict, List, Set, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+class TypeErrorCounter(object):
+  def __init__(self):
+    self._callCounts: Dict[Tuple[str, str], int] = dict()
+    self._typeErrors: Dict[Tuple[str, str], Counter[str]] = dict()
+    self._lock = Lock()
+
+  def log_errors(self, method: str, callsite: str, errors: List[str]) -> None:
+    key = (method, callsite)
+    with self._lock:
+      if key not in self._callCounts:
+        self._callCounts[key] = 0
+      self._callCounts[key] += 1
+      if key not in self._typeErrors:
+        self._typeErrors[key] = Counter()
+      for error in errors:
+        self._typeErrors[key][error] += 1
+
+  def get_summary(self):
+    lines = []
+    keys = [
+      (method, -1 * count, callsite) for ((method, callsite), count) in self._callCounts.items()
+    ]
+    for method, count, callsite in sorted(keys):
+      lines.append(f"{method}: {-1 * count} BAD CALLS AT: {callsite.rstrip()}")
+      for error, errorCount in self._typeErrors[(method, callsite)].items():
+        lines.append(f"  {errorCount:3d}x  {error}")
+      lines.append("")
+    return "\n".join(lines)
+
+
+def get_check(fail: Any, lines: List[str], unsafeAllowed: Set[str]) -> Callable:
+  """Return a function which will either assert a condition or conditionally log."""
+
+  def _check(columns: Any, condition: bool, msg: str):
+    if isinstance(columns, str):
+      failDisabled = columns in unsafeAllowed
+    elif isinstance(columns, List):
+      failDisabled = all(col in unsafeAllowed for col in columns)
+    else:
+      # Note there are multiple circumstances where the type of Columns may not be a str
+      # or List[str], including when we are concatenating a Series (column name will be
+      # set to None), when there are mulit-level column names (column name will be a tuple)
+      # or when Pandas has set column names to a RangeIndex.
+      failDisabled = False
+    if fail and not failDisabled:
+      assert condition, msg
+    elif not condition:
+      if failDisabled:
+        lines.append(f"{msg} (allowed)")
+      else:
+        lines.append(f"{msg} (UNALLOWED)")
+
+  return _check
+
+
+def _log_errors(method: str, callsite: str, lines: List[str], counter: TypeErrorCounter) -> None:
+  if not lines:
+    return
+  counter.log_errors(method, callsite, lines)
+  errorLines = "\n".join([f"  PandasTypeError: {l}" for l in lines])
+  msg = f"\n{method} ERROR AT: {callsite}" f"{method} ERRORS:\n{errorLines}\n"
+  print(msg, file=sys.stderr)
+
+
+def safe_concat(fail: bool, counter: TypeErrorCounter) -> Callable:
+  """Return a modified concat function that checks type stability.
+
+  Args:
+    fail: If True, unexpected type conversions should trigger a failed assert.  If False,
+      unexpected conversions should log to stderr.
+    counter: Tracker for summarizing problematic calls at the end of execution.
+  """
+  original = pd.concat
+
+  def _safe_concat(*args, **kwargs):
+    """Wrapper around pd.concat
+
+    Args:
+      args: non-keyword arguments to pass through to merge.
+      kwargs: keyword arguments to pass through to merge.
+    """
+    lines = []
+    if "unsafeAllowed" in kwargs:
+      unsafeAllowed = kwargs["unsafeAllowed"]
+      if isinstance(unsafeAllowed, str):
+        unsafeAllowed = {unsafeAllowed}
+      del kwargs["unsafeAllowed"]
+    else:
+      unsafeAllowed: Set[str] = set()
+    check = get_check(fail, lines, unsafeAllowed)
+    # Validate that all objects being concatenated are either Series or DataFrames
+    objs = args[0]
+    assert type(objs) == list, f"expected first argument to be a list: type={type(objs)}"
+    assert all(type(obj) == pd.Series for obj in objs) or all(
+      type(obj) == pd.DataFrame for obj in objs
+    ), f"Expected concat args to be either pd.Series or pd.DataFrame: {[type(obj) for obj in objs]}"
+    if type(objs[0]) == pd.Series:
+      if "axis" in kwargs and kwargs["axis"] == 1:
+        # Since the call is concatenating Series as columns in a DataFrame, validate that the sequence
+        # of Series dtypes matches the sequence of column dtypes in the dataframe.
+        result = original(*args, **kwargs)
+        objDtypes = [obj.dtype for obj in objs]
+        assert len(objDtypes) == len(
+          result.dtypes
+        ), f"dtype length mismatch: {len(objDtypes)} vs {len(result.dtypes)}"
+        for col, seriesType, colType in zip(result.columns, objDtypes, result.dtypes):
+          check(col, seriesType == colType, f"Series concat on {col}: {seriesType} vs {colType}")
+      else:
+        # If Series, validate that all series were same type and return
+        seriesTypes = set(obj.dtype for obj in objs)
+        check(None, len(seriesTypes) == 1, f"More than 1 unique Series type: {seriesTypes}")
+        result = original(*args, **kwargs)
+    else:
+      # If DataFrame, validate that all input columns with matching names have the same type
+      # and build expectation for output column types
+      assert type(objs[0]) == pd.DataFrame
+      colTypes: Dict[str, List[type]] = dict()
+      for df in objs:
+        for col, dtype in df.reset_index(drop=False).dtypes.items():
+          if col not in colTypes:
+            colTypes[col] = []
+          colTypes[col].append(dtype)
+      # Perform concatenation and validate that there weren't any type changes
+      result = original(*args, **kwargs)
+      for col, outputType in result.reset_index(drop=False).dtypes.items():
+        check(
+          col,
+          all(inputType == outputType for inputType in colTypes[col]),
+          f"DataFrame concat on {col}: output={outputType} inputs={colTypes[col]}",
+        )
+    _log_errors("CONCAT", traceback.format_stack()[-2], lines, counter)
+    return result
+
+  return _safe_concat
+
+
+def safe_merge(fail: bool, counter: TypeErrorCounter) -> Callable:
+  """Return a modified merge function that checks type stability.
+
+  Args:
+    fail: If True, unexpected type conversions should trigger a failed assert.  If False,
+      unexpected conversions should log to stderr.
+    counter: Tracker for summarizing problematic calls at the end of execution.
+  """
+  original = pd.DataFrame.merge
+
+  def _safe_merge(*args, **kwargs):
+    """Wrapper around pd.DataFrame.merge.
+
+    Args:
+      args: non-keyword arguments to pass through to merge.
+      kwargs: keyword arguments to pass through to merge.
+    """
+    lines = []
+    if "unsafeAllowed" in kwargs:
+      unsafeAllowed = kwargs["unsafeAllowed"]
+      if isinstance(unsafeAllowed, str):
+        unsafeAllowed = {unsafeAllowed}
+      del kwargs["unsafeAllowed"]
+    else:
+      unsafeAllowed: Set[str] = set()
+    check = get_check(fail, lines, unsafeAllowed)
+    leftFrame = args[0]
+    rightFrame = args[1]
+    # Validate that argument types are as expected
+    assert type(leftFrame) is pd.DataFrame
+    assert type(rightFrame) is pd.DataFrame
+    # Store dtypes and validate that any common columns have the same type
+    leftDtypes = dict(leftFrame.reset_index(drop=False).dtypes)
+    rightDtypes = dict(rightFrame.reset_index(drop=False).dtypes)
+    for col in set(leftDtypes) & set(rightDtypes):
+      check(
+        col,
+        leftDtypes[col] == rightDtypes[col],
+        f"Input mismatch on {col}: left={leftDtypes[col]} vs right={rightDtypes[col]}",
+      )
+    # Identify the columns we are merging on, if left_on and right_on are unset
+    if "on" in kwargs and type(kwargs["on"]) == str:
+      onCols = set([kwargs["on"]])
+    elif "on" in kwargs and type(kwargs["on"]) == list:
+      onCols = set(kwargs["on"])
+    elif "left_on" in kwargs:
+      assert "on" not in kwargs, "not expecting both on and left_on"
+      assert "right_on" in kwargs, "expecting both left_on and right_on to be set"
+      onCols = set()
+    else:
+      assert "on" not in kwargs, f"""unexpected type for on: {type(kwargs["on"])}"""
+      onCols = set(leftFrame.columns) & set(rightFrame.columns)
+    # Validate that merge columns have matching types
+    if "left_on" in kwargs:
+      assert "right_on" in kwargs
+      left_on = kwargs["left_on"]
+      right_on = kwargs["right_on"]
+      check(
+        [left_on, right_on],
+        leftDtypes[left_on] == rightDtypes[right_on],
+        f"Merge key mismatch on type({left_on})={leftDtypes[left_on]} vs type({right_on})={rightDtypes[right_on]}",
+      )
+    else:
+      assert len(onCols), "expected onCols to be defined since left_on was not"
+      assert "right_on" not in kwargs, "did not expect onCols and right_on"
+      for col in onCols:
+        check(
+          col,
+          leftDtypes[col] == rightDtypes[col],
+          f"Merge key mismatch on {col}: left={leftDtypes[col]} vs right={rightDtypes[col]}",
+        )
+    # Compute expected column types
+    leftSuffix, rightSuffix = kwargs.get("suffixes", ("_x", "_y"))
+    commonCols = set(leftFrame.columns) & set(rightFrame.columns)
+    expectedColTypes = dict()
+    for col in set(leftFrame.columns) | set(rightFrame.columns):
+      if col in onCols:
+        # Note that we check above whether leftDtypes[col] == rightDtypes[col] and either raise an
+        # error or log as appropriate if there is a mismatch.
+        if leftDtypes[col] == rightDtypes[col]:
+          expectedColTypes[col] = leftDtypes[col]
+        else:
+          # Set expectation to None since we don't know what will happen, but do want to log an
+          # error later
+          expectedColTypes[col] = None
+      elif col in commonCols:
+        expectedColTypes[f"{col}{leftSuffix}"] = leftDtypes[col]
+        expectedColTypes[f"{col}{rightSuffix}"] = rightDtypes[col]
+      elif col in leftDtypes:
+        assert col not in rightDtypes
+        expectedColTypes[col] = leftDtypes[col]
+      else:
+        expectedColTypes[col] = rightDtypes[col]
+    # Perform merge and validate results
+    result = original(*args, **kwargs)
+    resultDtypes = dict(result.dtypes)
+    for col in resultDtypes:
+      check(
+        col,
+        resultDtypes[col] == expectedColTypes[col],
+        f"Output mismatch on {col}: result={resultDtypes[col]} expected={expectedColTypes[col]}",
+      )
+    _log_errors("MERGE", traceback.format_stack()[-2], lines, counter)
+    return result
+
+  return _safe_merge
+
+
+def _get_multiindex_types(df: pd.DataFrame):
+  """Create a dictionary mapping index columns to dtypes.
+
+  Note that this approach may mis-type columns under rare circumstances.  See example below:
+  # left = pd.DataFrame({"idx0": [1, 2], "idx1": [11, 12], "val1": [4, 5]}).set_index(["idx0", "idx1"])
+  # right = pd.DataFrame({"idx0": [1, 2, 3], "idx2": [21, 22, 23], "val2": [7, 8, 9]}).set_index(["idx0", "idx2"])
+  # print(dict(left.join(right, how="outer").index.dtypes))
+  # print(dict(left.join(right, how="outer").reset_index(drop=False).dtypes))
+  # $> {'idx0': dtype('int64'), 'idx1': dtype('int64'), 'idx2': dtype('int64')}
+  # $> {'idx0': dtype('int64'), 'idx1': dtype('float64'), 'idx2': dtype('int64'), 'val1': dtype('float64'), 'val2': dtype('int64')}
+
+  Unfortunatley, Pandas 1.1.5 seem to treat the type of multi-level indexes as "object"
+  as the "dtypes" property is not defined for MultiIndex and df.index.dtype and
+  df.index.values.dtype both return dtype('O').  At some point bewteen Pandas 1.1.5
+  and 2.2.2, the dtypes attribute was defined for MultiIndex and dict(df.index.dtypes)
+  yields a mapping from index columns to their actual datatype.
+  """
+  dfTypes = dict(df.reset_index(drop=False).dtypes)
+  indexCols = set(df.index.names)
+  return {col: dtype for (col, dtype) in dfTypes.items() if col in indexCols}
+
+
+def safe_join(fail: bool, counter: TypeErrorCounter) -> Callable:
+  """Return a modified merge function that checks type stability.
+
+  Args:
+    fail: If True, unexpected type conversions should trigger a failed assert.  If False,
+      unexpected conversions should log to stderr.
+    counter: Tracker for summarizing problematic calls at the end of execution.
+  """
+  original = pd.DataFrame.join
+
+  def _safe_join(*args, **kwargs):
+    """Wrapper around pd.DataFrame.merge.
+
+    Args:
+      args: non-keyword arguments to pass through to merge.
+      kwargs: keyword arguments to pass through to merge.
+    """
+    lines = []
+    if "unsafeAllowed" in kwargs:
+      unsafeAllowed = kwargs["unsafeAllowed"]
+      if isinstance(unsafeAllowed, str):
+        unsafeAllowed = {unsafeAllowed}
+      del kwargs["unsafeAllowed"]
+    else:
+      unsafeAllowed: Set[str] = set()
+    check = get_check(fail, lines, unsafeAllowed)
+    leftFrame = args[0]
+    rightFrame = args[1]
+    # Validate arguments are as expected
+    assert type(leftFrame) is pd.DataFrame
+    assert type(rightFrame) is pd.DataFrame
+    assert len(set(kwargs) - {"lsuffix", "rsuffix", "how"}) == 0, f"unexpected kwargs: {kwargs}"
+    # Validate the assumption that columns used as the join key in the index have the same type.
+    # This is analogous to validating that onCols match and have the same types in _safe_merge.
+    if len(leftFrame.index.names) == 1 and len(rightFrame.index.names) == 1:
+      match = leftFrame.index.dtype == rightFrame.index.dtype
+    elif len(leftFrame.index.names) == 1 and len(rightFrame.index.names) > 1:
+      indexTypes = _get_multiindex_types(rightFrame)
+      name = leftFrame.index.names[0]
+      assert name in indexTypes, f"{name} not found in {indexTypes}"
+      match = indexTypes[name] == leftFrame.index.dtype
+    elif len(leftFrame.index.names) > 1 and len(rightFrame.index.names) == 1:
+      indexTypes = _get_multiindex_types(leftFrame)
+      name = rightFrame.index.names[0]
+      assert name in indexTypes, f"{name} not found in {indexTypes}"
+      match = indexTypes[name] == rightFrame.index.dtype
+    else:
+      assert (
+        len(leftFrame.index.names) > 1
+      ), f"unexpected left: {type(leftFrame.index)}, {leftFrame.index}"
+      assert (
+        len(rightFrame.index.names) > 1
+      ), f"unexpected right: {type(rightFrame.index)}, {rightFrame.index}"
+      leftIndexTypes = _get_multiindex_types(leftFrame)
+      rightIndexTypes = _get_multiindex_types(rightFrame)
+      match = True
+      for col in set(leftIndexTypes) & set(rightIndexTypes):
+        match = match & (leftIndexTypes[col] == rightIndexTypes[col])
+    assert match, f"Join index mismatch:\n{leftFrame.index}\nvs\n{rightFrame.index}"
+    # Validate that input columns with the same name have the same types
+    leftDtypes = dict(leftFrame.dtypes)
+    rightDtypes = dict(rightFrame.dtypes)
+    for col in set(leftDtypes) & set(rightDtypes):
+      check(
+        col,
+        leftDtypes[col] == rightDtypes[col],
+        f"Input mismatch on {col}: left={leftDtypes[col]} vs right={rightDtypes[col]}",
+      )
+    # Validate that none of the columns in an index have the same name as a non-index column
+    # in the opposite dataframe
+    assert (
+      len(set(leftFrame.index.names) & set(rightFrame.columns)) == 0
+    ), f"left index: {set(leftFrame.index.names)}; right columns {set(rightFrame.columns)}"
+    assert (
+      len(set(rightFrame.index.names) & set(leftFrame.columns)) == 0
+    ), f"right index: {set(rightFrame.index.names)}; left columns {set(leftFrame.columns)}"
+    # Compute expected types for output columns
+    commonCols = set(leftFrame.columns) & set(rightFrame.columns)
+    expectedColTypes = dict()
+    leftSuffix = kwargs.get("lsuffix", "")
+    rightSuffix = kwargs.get("rsuffix", "")
+    for col in set(leftFrame.columns) | set(rightFrame.columns):
+      if col in commonCols:
+        expectedColTypes[f"{col}{leftSuffix}"] = leftDtypes[col]
+        expectedColTypes[f"{col}{rightSuffix}"] = rightDtypes[col]
+      elif col in leftDtypes:
+        assert col not in rightDtypes
+        expectedColTypes[col] = leftDtypes[col]
+      else:
+        expectedColTypes[col] = rightDtypes[col]
+    # Compute expected types for index columns
+    leftIndexCols = set(leftFrame.index.names)
+    rightIndexCols = set(rightFrame.index.names)
+    if len(leftIndexCols) > 1:
+      leftDtypes = _get_multiindex_types(leftFrame)
+    else:
+      leftDtypes = {leftFrame.index.name: leftFrame.index.dtype}
+    if len(rightIndexCols) > 1:
+      rightDtypes = _get_multiindex_types(rightFrame)
+    else:
+      rightDtypes = {rightFrame.index.name: rightFrame.index.dtype}
+    for col in leftIndexCols & rightIndexCols:
+      # For columns in both indices, type should not change if input types agree.  If input types
+      # disagree, then we have no expectation.
+      if leftDtypes[col] == rightDtypes[col]:
+        expectedColTypes[col] = leftDtypes[col]
+      else:
+        expectedColTypes[col] = None
+    for col in (leftIndexCols | rightIndexCols) - (leftIndexCols & rightIndexCols):
+      # For columns in exactly one index, the expected output type should match the input column type
+      # and the column name should not change because we have validated that the column does not
+      # appear in the other dataframe
+      if col in leftDtypes:
+        assert col not in rightDtypes, f"unexpected column: {col}"
+        expectedColTypes[col] = leftDtypes[col]
+      else:
+        expectedColTypes[col] = rightDtypes[col]
+    # Perform join and validate results.  Note that we already validated that the indices had the
+    # same columns and types, and that the "on" argument is unset, so now we only need to check
+    # the non-index columns.
+    result = original(*args, **kwargs)
+    # Note that we must reset index to force any NaNs in the index to emerge as float types.
+    # See example below.
+    # left = pd.DataFrame({"idx0": [1, 2], "idx1": [11, 12], "val1": [4, 5]}).set_index(["idx0", "idx1"])
+    # right = pd.DataFrame({"idx0": [1, 2, 3], "idx2": [21, 22, 23], "val2": [7, 8, 9]}).set_index(["idx0", "idx2"])
+    # print(dict(left.join(right, how="outer").index.dtypes))
+    # print(dict(left.join(right, how="outer").reset_index(drop=False).dtypes))
+    # $> {'idx0': dtype('int64'), 'idx1': dtype('int64'), 'idx2': dtype('int64')}
+    # $> {'idx0': dtype('int64'), 'idx1': dtype('float64'), 'idx2': dtype('int64'), 'val1': dtype('float64'), 'val2': dtype('int64')}
+    resultDtypes = dict(result.reset_index(drop=False).dtypes)
+    # Add default type for index
+    if "index" not in expectedColTypes:
+      expectedColTypes["index"] = np.int64
+    for col, dtype in resultDtypes.items():
+      if len(col) == 2 and col[1] == "":
+        col = col[0]
+      check(
+        col,
+        dtype == expectedColTypes[col],
+        f"Output mismatch on {col}: result={dtype} expected={expectedColTypes[col]}",
+      )
+    _log_errors("JOIN", traceback.format_stack()[-2], lines, counter)
+    return result
+
+  return _safe_join
+
+
+def patch_pandas(main: Callable) -> Callable:
+  """Return a decorator for wrapping main with pandas patching and logging
+
+  Args:
+    main: "main" function for program binary
+  """
+
+  def _inner(*args, **kwargs) -> Any:
+    """Determine patching behavior, apply patch and add logging."""
+    print("Patching pandas")
+    if "args" in kwargs:
+      # Handle birdwatch/scoring/src/main/python/public/scoring/runner.py, which expects
+      # args as a keyword argument and not as a positional argument.
+      assert len(args) == 0, f"positional arguments not expected, but found {len(args)}"
+      clArgs = kwargs["args"]
+    else:
+      # Handle the following, which expect args as the second positional argument:
+      # birdwatch/scoring/src/main/python/run_prescoring.py
+      # birdwatch/scoring/src/main/python/run_final_scoring.py
+      # birdwatch/scoring/src/main/python/run_contributor_scoring.py
+      # birdwatch/scoring/src/main/python/run.py
+      assert len(args) == 1, f"unexpected 1 positional args, but found {len(args)}"
+      assert len(kwargs) == 0, f"expected kwargs to be empty, but found {len(kwargs)}"
+      clArgs = args[0]
+    # Apply patches, configured based on whether types should be enforced or logged
+    counter = TypeErrorCounter()
+    pd.concat = safe_concat(clArgs.enforce_types, counter)
+    # Note that this will work when calling df1.merge(df2) because the first argument
+    # to "merge" is df1 (i.e. self).
+    pd.DataFrame.merge = safe_merge(clArgs.enforce_types, counter)
+    pd.DataFrame.join = safe_join(clArgs.enforce_types, counter)
+    # Run main
+    retVal = main(*args, **kwargs)
+    # Log type error summary
+    if hasattr(clArgs, "parallel") and not clArgs.parallel:
+      print(f"\nTYPE WARNING SUMMARY\n{counter.get_summary()}", file=sys.stderr)
+    else:
+      # Don't show type summary because counters will be inaccurate due to scorers running
+      # in their own process.
+      print("Type summary omitted when running in parallel.", file=sys.stderr)
+    # Return result of main
+    return retVal
+
+  return _inner

--- a/sourcecode/scoring/post_selection_similarity.py
+++ b/sourcecode/scoring/post_selection_similarity.py
@@ -68,6 +68,7 @@ def filter_ratings_by_post_selection_similarity(notes, ratings, postSelectionSim
       postSelectionSimilarityValues,
       on=c.raterParticipantIdKey,
       how="left",
+      unsafeAllowed=c.postSelectionValueKey,
     )
     .merge(notes[[c.noteIdKey, c.noteAuthorParticipantIdKey]], on=c.noteIdKey, how="left")
     .merge(
@@ -76,6 +77,7 @@ def filter_ratings_by_post_selection_similarity(notes, ratings, postSelectionSim
       right_on=c.raterParticipantIdKey,
       how="left",
       suffixes=("", "_note_author"),
+      unsafeAllowed={c.postSelectionValueKey, c.postSelectionValueKey + "_note_author"},
     )
   )
   ratingsWithNoPostSelectionSimilarityValue = ratingsWithPostSelectionSimilarity[

--- a/sourcecode/scoring/reputation_scorer.py
+++ b/sourcecode/scoring/reputation_scorer.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from . import constants as c
 from .matrix_factorization.matrix_factorization import MatrixFactorization
@@ -88,6 +88,12 @@ class ReputationScorer(Scorer):
   def _get_dropped_user_cols(self) -> List[str]:
     """Returns a list of columns which should be excluded from helpfulnessScores output."""
     return []
+
+  def _get_user_col_mapping(self) -> Dict[str, str]:
+    """Returns a dict mapping default user column names to custom names for a specific model."""
+    return {
+      c.internalRaterReputationKey: c.raterHelpfulnessReputationKey,
+    }
 
   def _filter_input(
     self,

--- a/sourcecode/scoring/runner.py
+++ b/sourcecode/scoring/runner.py
@@ -1,14 +1,44 @@
 import argparse
 import os
+import sys
 
 from . import constants as c
 from .enums import scorers_from_csv
-from .process_data import LocalDataLoader, write_parquet_local, write_tsv_local
+from .pandas_utils import patch_pandas
+from .process_data import LocalDataLoader, tsv_reader, write_parquet_local, write_tsv_local
 from .run_scoring import run_scoring
+
+import pandas as pd
 
 
 def parse_args():
   parser = argparse.ArgumentParser("Community Notes Scoring")
+  parser.add_argument(
+    "--check-flips",
+    dest="check_flips",
+    help="Validate that note statuses align with prior runs (disable for testing)",
+    action="store_true",
+  )
+  parser.add_argument(
+    "--nocheck-flips",
+    help="Disable validation that note statuses align with prior runs (use for testing)",
+    action="store_false",
+    dest="check_flips",
+  )
+  parser.set_defaults(check_flips=True)
+  parser.add_argument(
+    "--enforce-types",
+    dest="enforce_types",
+    help="Raise errors when types in Pandas operations do not meet expectations.",
+    action="store_true",
+  )
+  parser.add_argument(
+    "--noenforce-types",
+    dest="enforce_types",
+    help="Log to stderr when types in Pandas operations do not meet expectations.",
+    action="store_false",
+  )
+  parser.set_defaults(enforce_types=True)
   parser.add_argument(
     "-e", "--enrollment", default=c.enrollmentInputPath, help="note enrollment dataset"
   )
@@ -33,6 +63,15 @@ def parse_args():
   )
   parser.set_defaults(headers=True)
   parser.add_argument("-n", "--notes", default=c.notesInputPath, help="note dataset")
+  parser.add_argument(
+    "--previous-scored-notes", default=None, help="previous scored notes dataset path"
+  )
+  parser.add_argument(
+    "--previous-aux-note-info", default=None, help="previous aux note info dataset path"
+  )
+  parser.add_argument(
+    "--previous-rating-cutoff-millis", default=None, type=int, help="previous rating cutoff millis"
+  )
   parser.add_argument("-o", "--outdir", default=".", help="directory for output files")
   parser.add_argument(
     "--pseudoraters",
@@ -118,14 +157,13 @@ def parse_args():
   return parser.parse_args()
 
 
-def main(
+@patch_pandas
+def _run_scorer(
   args=None,
   dataLoader=None,
   extraScoringArgs={},
 ):
-  # Parse arguments and fix timestamp, if applicable.
-  if args is None:
-    args = parse_args()
+  assert args is not None, "args must be available"
   if args.epoch_millis:
     c.epochMillis = args.epoch_millis
     c.useCurrentTimeInsteadOfEpochMillisForNoteStatusHistory = False
@@ -140,6 +178,27 @@ def main(
       args.headers,
     )
   notes, ratings, statusHistory, userEnrollment = dataLoader.get_data()
+  if args.previous_scored_notes is not None:
+    previousScoredNotes = tsv_reader(
+      args.previous_scored_notes,
+      c.noteModelOutputTSVTypeMapping,
+      c.noteModelOutputTSVColumns,
+      header=False,
+      convertNAToNone=False,
+    )
+    assert (
+      args.previous_aux_note_info is not None
+    ), "previous_aux_note_info must be available if previous_scored_notes is available"
+    previousAuxiliaryNoteInfo = tsv_reader(
+      args.previous_aux_note_info,
+      c.auxiliaryScoredNotesTSVTypeMapping,
+      c.auxiliaryScoredNotesTSVColumns,
+      header=False,
+      convertNAToNone=False,
+    )
+  else:
+    previousScoredNotes = None
+    previousAuxiliaryNoteInfo = None
 
   # Invoke scoring and user contribution algorithms.
   scoredNotes, helpfulnessScores, newStatus, auxNoteInfo = run_scoring(
@@ -157,6 +216,10 @@ def main(
     excludeRatingsAfterANoteGotFirstStatusPlusNHours=args.excludeRatingsAfterANoteGotFirstStatusPlusNHours,
     daysInPastToApplyPostFirstStatusFiltering=args.daysInPastToApplyPostFirstStatusFiltering,
     filterPrescoringInputToSimulateDelayInHours=args.prescoring_delay_hours,
+    checkFlips=args.check_flips,
+    previousScoredNotes=previousScoredNotes,
+    previousAuxiliaryNoteInfo=previousAuxiliaryNoteInfo,
+    previousRatingCutoffTimestampMillis=args.previous_rating_cutoff_millis,
     **extraScoringArgs,
   )
 
@@ -171,6 +234,20 @@ def main(
     write_parquet_local(helpfulnessScores, os.path.join(args.outdir, "helpfulness_scores.parquet"))
     write_parquet_local(newStatus, os.path.join(args.outdir, "note_status_history.parquet"))
     write_parquet_local(auxNoteInfo, os.path.join(args.outdir, "aux_note_info.parquet"))
+
+
+def main(
+  args=None,
+  dataLoader=None,
+  extraScoringArgs={},
+):
+  if args is None:
+    args = parse_args()
+  print(f"scorer python version: {sys.version}")
+  print(f"scorer pandas version: {pd.__version__}")
+  # patch_pandas requires that args are available (which matches the production binary) so
+  # we first parse the arguments then invoke the decorated _run_scorer.
+  return _run_scorer(args=args, dataLoader=dataLoader, extraScoringArgs=extraScoringArgs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Multiple changes that don't affect final note statuses:

Splitting the main scorer into smaller chunks:
1. Enable scoring note subsets in final_note_scoring (this is much faster than rescoring all notes, if you are using frozen rater parameters).
2. Split final_scoring into separately runnable final_note_scoring and contributor_scoring jobs.

Version upgrading and type-safety improvements:
3. Add pandas type-checking util for type-safe merges, joins, and concats.
4. Migrate to pandas 2.2.2 and Python 3.10.

Note: contributions are blended together from multiple authors, esp. @bradmiller.