### PR TITLE
update GazaConflict to GazaOccupation to reflect recent ICJ ruling

### DIFF
--- a/sourcecode/scoring/enums.py
+++ b/sourcecode/scoring/enums.py
@@ -20,7 +20,7 @@ class Topics(Enum):
 
   Unassigned = 0
   UkraineConflict = 1
-  GazaConflict = 2
+  GazaOccupation = 2
   MessiRonaldo = 3
 
 

--- a/sourcecode/scoring/topic_model.py
+++ b/sourcecode/scoring/topic_model.py
@@ -36,7 +36,7 @@ class TopicModel(object):
         "zelensky",
         "putin",
       },
-      Topics.GazaConflict: {
+      Topics.GazaOccupation: {
         "israel",
         "palestin",  # intentionally shortened for expanded matching
         "gaza",


### PR DESCRIPTION
The ICJ (International Court of Justice) has recently issued an advisory opinion determining that the Israel-Gaza situation is considered an occupation/apartheid, not a simple conflict. I have updated both `sourcecode/scoring/enums.py` and `sourcecode/scoring/topic_model.py` to reflect this. 

I understand that this will make just about no difference to the end user experience.

I also understand that since Community Notes is here to fight misinformation, add missing context, and correct outdated information, we should be able to correct such things in the source code as well.

## Sources for the ICJ ruling:
[The International Court of Justice](https://www.icj-cij.org/sites/default/files/case-related/186/186-20240719-adv-01-00-en.pdf)
[Human Rights Watch](https://www.hrw.org/news/2024/07/19/world-court-finds-israel-responsible-apartheid)
[New Arab](https://www.newarab.com/news/icj-israel-policies-occupied-palestine-amounts-apartheid)
[Middle East Eye](https://www.middleeasteye.net/news/icj-delivers-landmark-opinion-57-year-israeli-occupation)
[The Intercept](https://theintercept.com/2024/07/19/icj-ruling-palestine-israel-occupation-settlements/)
[Palestine Solidarity Campaign](https://palestinecampaign.org/icj-ruling-finds-israel-guilty-of-unlawful-occupation-and-apartheid/)
[Middle East Monitor](https://www.middleeastmonitor.com/20240720-icj-israels-policy-of-racial-segregation-and-apartheid/)
[Amnesty International](https://www.amnesty.org/en/latest/news/2024/07/icj-opinion-declaring-israels-occupation-of-palestinian-territories-unlawful-is-historic-vindication-of-palestinians-rights/)