### PR TITLE
Allow scorers to firm_reject, finish split scorer refactoring & QOL++

### DIFF
--- a/sourcecode/scoring/constants.py
+++ b/sourcecode/scoring/constants.py
@@ -36,7 +36,8 @@ intervalHalfWidth = 0.3
 # Max flip rates
 prescoringAllUnlockedNotesMaxCrhChurn = 0.04
 finalUnlockedNotesWithNoNewRatingsMaxCrhChurn = 0.03
-finalNotesWithNewRatingsMaxCrhChurn = 0.40
+finalNotesWithNewRatingsMaxNewCrhChurn = 0.80
+finalNotesWithNewRatingsMaxOldCrhChurn = 0.25
 finalNotesThatJustFlippedStatusMaxCrhChurn = 1e8
 finalNotesThatFlippedRecentlyMaxCrhChurn = 1e8
 
@@ -236,6 +237,9 @@ raterAgreeRatioWithHarassmentAbusePenaltyKey = "raterAgreeRatioKeyWithHarassment
 currentlyRatedHelpful = "CURRENTLY_RATED_HELPFUL"
 currentlyRatedNotHelpful = "CURRENTLY_RATED_NOT_HELPFUL"
 needsMoreRatings = "NEEDS_MORE_RATINGS"
+# FIRM_REJECT is set by individual scorers to indicate downstream scorers should not CRH
+# a note, but is never set as the finalRatingStatus of a note.
+firmReject = "FIRM_REJECT"
 
 # Boolean Note Status Labels
 currentlyRatedHelpfulBoolKey = "crhBool"
@@ -511,7 +515,7 @@ userEnrollmentTSVColumnsAndTypes = [
   (successfulRatingNeededToEarnIn, np.int64),
   (timestampOfLastStateChange, np.int64),
   (timestampOfLastEarnOut, np.double),  # double because nullable.
-  (modelingPopulationKey, str),
+  (modelingPopulationKey, "category"),
   (modelingGroupKey, np.float64),
   (numberOfTimesEarnedOutKey, np.int64),
 ]
@@ -801,6 +805,9 @@ class PrescoringMetaScorerOutput:
   globalIntercept: Optional[float]
   lowDiligenceGlobalIntercept: Optional[ReputationGlobalIntercept]
   tagFilteringThresholds: Optional[Dict[str, float]]  # tag => threshold
+  finalRoundNumRatings: Optional[int]
+  finalRoundNumNotes: Optional[int]
+  finalRoundNumUsers: Optional[int]
 
 
 @dataclass
@@ -886,5 +893,6 @@ class RescoringRuleID(Enum):
 @dataclass
 class NoteSubset:
   noteSet: Optional[set]
-  maxCrhChurnRate: float
+  maxNewCrhChurnRate: float
+  maxOldCrhChurnRate: float
   description: RescoringRuleID

--- a/sourcecode/scoring/matrix_factorization/model.py
+++ b/sourcecode/scoring/matrix_factorization/model.py
@@ -7,8 +7,8 @@ import torch
 @dataclass
 class ModelData:
   rating_labels: Optional[torch.FloatTensor]
-  user_indexes: Optional[torch.LongTensor]
-  note_indexes: Optional[torch.LongTensor]
+  user_indexes: Optional[torch.IntTensor]
+  note_indexes: Optional[torch.IntTensor]
 
 
 class BiasedMatrixFactorization(torch.nn.Module):
@@ -35,14 +35,14 @@ class BiasedMatrixFactorization(torch.nn.Module):
 
     self._logging = logging
 
-    self.user_factors = torch.nn.Embedding(n_users, n_factors, sparse=False)
-    self.note_factors = torch.nn.Embedding(n_notes, n_factors, sparse=False)
+    self.user_factors = torch.nn.Embedding(n_users, n_factors, sparse=False, dtype=torch.float32)
+    self.note_factors = torch.nn.Embedding(n_notes, n_factors, sparse=False, dtype=torch.float32)
 
-    self.user_intercepts = torch.nn.Embedding(n_users, 1, sparse=False)
-    self.note_intercepts = torch.nn.Embedding(n_notes, 1, sparse=False)
+    self.user_intercepts = torch.nn.Embedding(n_users, 1, sparse=False, dtype=torch.float32)
+    self.note_intercepts = torch.nn.Embedding(n_notes, 1, sparse=False, dtype=torch.float32)
 
     self.use_global_intercept = use_global_intercept
-    self.global_intercept = torch.nn.parameter.Parameter(torch.zeros(1, 1))
+    self.global_intercept = torch.nn.parameter.Parameter(torch.zeros(1, 1, dtype=torch.float32))
     torch.nn.init.xavier_uniform_(self.user_factors.weight)
     torch.nn.init.xavier_uniform_(self.note_factors.weight)
     self.user_intercepts.weight.data.fill_(0.0)

--- a/sourcecode/scoring/matrix_factorization/normalized_loss.py
+++ b/sourcecode/scoring/matrix_factorization/normalized_loss.py
@@ -125,9 +125,16 @@ class NormalizedLoss(torch.nn.Module):
     # Finalize weights
     weightMap = dict(
       ((rater, note), weight)
-      for (rater, note, weight) in ratings[[c.raterParticipantIdKey, c.noteIdKey, "weights"]].values
+      for (rater, note, weight) in zip(
+        ratings[c.raterParticipantIdKey], ratings[c.noteIdKey], ratings["weights"]
+      )
     )
-    self.weights = torch.tensor([weightMap[(rater, note)] for (rater, note) in ratingOrder.values])
+    self.weights = torch.FloatTensor(
+      [
+        weightMap[(rater, note)]
+        for (rater, note) in zip(ratingOrder[c.raterParticipantIdKey], ratingOrder[c.noteIdKey])
+      ]
+    )
     assert len(self.weights) == len(self.targets)
 
   def forward(self, pred):

--- a/sourcecode/scoring/matrix_factorization/pseudo_raters.py
+++ b/sourcecode/scoring/matrix_factorization/pseudo_raters.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from .. import constants as c
 from .matrix_factorization import Constants as mf_c, MatrixFactorization
 
+import numpy as np
 import pandas as pd
 import torch
 
@@ -236,6 +237,13 @@ class PseudoRatersRunner:
       extremeRatingsToAdd = pd.DataFrame(ratingsWithNoteIds).drop(
         [c.internalRaterInterceptKey, c.internalRaterFactor1Key], axis=1
       )
+      extremeRatingsToAdd[c.noteIdKey] = extremeRatingsToAdd[c.noteIdKey].astype(np.int64)
+      if isinstance(self.ratingFeaturesAndLabels[c.raterParticipantIdKey].dtype, pd.Int64Dtype):
+        # Only convert ID type from string to Int64 if is necessary to match existing IDs (which is
+        # expected when running in prod, but not always in unit tests or public data.)
+        extremeRatingsToAdd[c.raterParticipantIdKey] = extremeRatingsToAdd[
+          c.raterParticipantIdKey
+        ].astype(pd.Int64Dtype())
       ratingFeaturesAndLabelsWithExtremeRatings = pd.concat(
         [self.ratingFeaturesAndLabels, extremeRatingsToAdd]
       )

--- a/sourcecode/scoring/mf_core_scorer.py
+++ b/sourcecode/scoring/mf_core_scorer.py
@@ -12,6 +12,7 @@ class MFCoreScorer(MFBaseScorer):
     useStableInitialization: bool = True,
     saveIntermediateState: bool = False,
     threads: int = c.defaultNumThreads,
+    firmRejectThreshold: Optional[float] = 0.3,
   ) -> None:
     """Configure MFCoreScorer object.
 
@@ -29,6 +30,7 @@ class MFCoreScorer(MFBaseScorer):
       useStableInitialization=useStableInitialization,
       saveIntermediateState=saveIntermediateState,
       threads=threads,
+      firmRejectThreshold=firmRejectThreshold,
     )
 
   def get_name(self):

--- a/sourcecode/scoring/mf_expansion_scorer.py
+++ b/sourcecode/scoring/mf_expansion_scorer.py
@@ -14,6 +14,7 @@ class MFExpansionScorer(MFBaseScorer):
     useStableInitialization: bool = True,
     saveIntermediateState: bool = False,
     threads: int = c.defaultNumThreads,
+    firmRejectThreshold: Optional[float] = 0.3,
   ) -> None:
     """Configure MFExpansionScorer object.
 
@@ -30,6 +31,7 @@ class MFExpansionScorer(MFBaseScorer):
       useStableInitialization=useStableInitialization,
       saveIntermediateState=saveIntermediateState,
       threads=threads,
+      firmRejectThreshold=firmRejectThreshold,
     )
 
   def get_name(self):

--- a/sourcecode/scoring/process_data.py
+++ b/sourcecode/scoring/process_data.py
@@ -4,6 +4,7 @@ import os
 from typing import Dict, List, Optional, Tuple
 
 from . import constants as c, note_status_history
+from .pandas_utils import get_df_info
 
 import joblib
 import numpy as np
@@ -91,6 +92,9 @@ def tsv_parser(
         usecols=useCols,
       )
     if convertNAToNone:
+      print("Logging size effect of convertNAToNone")
+      print("Before conversion:")
+      print(get_df_info(data))
       # float types will be nan if missing; newer nullable types like "StringDtype" or "Int64Dtype" will by default
       # be pandas._libs.missing.NAType if missing. Set those to None and change the dtype back to object.
       for colname, coltype in mapping.items():
@@ -100,6 +104,8 @@ def tsv_parser(
         ):
           data[colname] = data[colname].astype(object)
           data.loc[pd.isna(data[colname]), colname] = None
+      print("After conversion:")
+      print(get_df_info(data))
     return data
   except (ValueError, IndexError) as e:
     raise ValueError(f"Invalid input: {e}")

--- a/sourcecode/scoring/reputation_matrix_factorization/dataset.py
+++ b/sourcecode/scoring/reputation_matrix_factorization/dataset.py
@@ -36,15 +36,16 @@ def build_dataset(
   """
   # Identify mappings from note and rater IDs to indices
   notes = ratings[c.noteIdKey].drop_duplicates().sort_values().values
-  noteIdToIndex = dict(zip(notes, np.arange(len(notes), dtype=np.int64)))
+  noteIdToIndex = dict(zip(notes, np.arange(len(notes), dtype=np.int32)))
   raters = ratings[c.raterParticipantIdKey].drop_duplicates().sort_values().values
-  raterIdToIndex = dict(zip(raters, np.arange(len(raters), dtype=np.int64)))
+  raterIdToIndex = dict(zip(raters, np.arange(len(raters), dtype=np.int32)))
   # Generate tensors
-  noteTensor = torch.tensor(
+  noteTensor = torch.IntTensor(
     [noteIdToIndex[noteId] for noteId in ratings[c.noteIdKey]], device=device
   )
-  raterTensor = torch.tensor(
-    [raterIdToIndex[raterId] for raterId in ratings[c.raterParticipantIdKey]], device=device
+  raterTensor = torch.IntTensor(
+    [raterIdToIndex[raterId] for raterId in ratings[c.raterParticipantIdKey]],
+    device=device,
   )
   targetTensor = torch.tensor(targets, device=device, dtype=torch.float32)
 

--- a/sourcecode/scoring/reputation_matrix_factorization/diligence_model.py
+++ b/sourcecode/scoring/reputation_matrix_factorization/diligence_model.py
@@ -15,6 +15,8 @@ import torch
 def _setup_dataset_and_hparams(
   filteredRatings: pd.DataFrame,
   device=torch.device("cpu"),
+  ratingsPerNoteLossRatio: Optional[float] = None,
+  ratingsPerUserLossRatio: Optional[float] = None,
 ):
   # Define dataset
   targets = (
@@ -62,6 +64,8 @@ def _setup_dataset_and_hparams(
     reputationExp=0.5,
     alpha=0.1,
     defaultReputation=1.0,
+    ratingPerNoteLossRatio=ratingsPerNoteLossRatio,  # 35.0, # approx 29377568 / 795977
+    ratingPerUserLossRatio=ratingsPerUserLossRatio,  # 75.0, # approx 29377568 / 265214
   )
   return dataset, hParams
 
@@ -89,6 +93,8 @@ def fit_low_diligence_model_final(
   noteInitStateDiligence: pd.DataFrame,
   raterInitStateDiligence: pd.DataFrame,
   globalInterceptDiligence: c.ReputationGlobalIntercept,
+  ratingsPerNoteLossRatio: Optional[float] = None,
+  ratingsPerUserLossRatio: Optional[float] = None,
   device=torch.device("cpu"),
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
   """
@@ -99,7 +105,9 @@ def fit_low_diligence_model_final(
     globalInterceptDiligence: float
     device: torch.device to use for training
   """
-  dataset, hParams = _setup_dataset_and_hparams(filteredRatings, device)
+  dataset, hParams = _setup_dataset_and_hparams(
+    filteredRatings, device, ratingsPerNoteLossRatio, ratingsPerUserLossRatio
+  )
   noteInitStateInternal, raterInitStateInternal = _prepare_diligence_init_state(
     noteInitStateDiligence, raterInitStateDiligence
   )

--- a/sourcecode/scoring/reputation_scorer.py
+++ b/sourcecode/scoring/reputation_scorer.py
@@ -137,7 +137,12 @@ class ReputationScorer(Scorer):
     )
 
     metaScorerOutput = c.PrescoringMetaScorerOutput(
-      globalIntercept=None, lowDiligenceGlobalIntercept=globalIntercept, tagFilteringThresholds=None
+      globalIntercept=None,
+      lowDiligenceGlobalIntercept=globalIntercept,
+      tagFilteringThresholds=None,
+      finalRoundNumRatings=None,
+      finalRoundNumNotes=None,
+      finalRoundNumUsers=None,
     )
     return noteStats, raterStats, metaScorerOutput
 

--- a/sourcecode/scoring/scorer.py
+++ b/sourcecode/scoring/scorer.py
@@ -250,7 +250,6 @@ class Scorer(ABC):
     print(
       f"prescore: Torch intra-op parallelism for {self.get_name()} set to: {torch.get_num_threads()}"
     )
-
     # Transform input, run core scoring algorithm, transform output.
     with self.time_block("Filter input"):
       ratings, noteStatusHistory = self._filter_input(


### PR DESCRIPTION
-Allow more-authoritative scorers to issue a FIRM_REJECT, which prevents less-authoritative scorers from being able to CRH a note, if the note scored poorly (<0.3 intercept) in the authoritative model. 
-Adjust MF loss function such that it is invariant to the ratings:users:notes ratios, allowing scoring to be split fully into a separate final scoring phase 
-Memory reduction & speedup from using smaller data types 
-Separate max flip rates for NMR=>CRH vs. CRH=>NMR transitions. 
-Speed up RAM profiling

As usual, code written by the whole team, not just me.