### PR TITLE
Multi-group models, Support NMRDueToStableCRHTime, & more

### DIFF
--- a/sourcecode/scoring/enums.py
+++ b/sourcecode/scoring/enums.py
@@ -13,6 +13,7 @@ class Scorers(Enum):
   MFExpansionPlusScorer = auto()
   ReputationScorer = auto()
   MFTopicScorer = auto()
+  MFMultiGroupScorer = auto()
 
 
 class Topics(Enum):

--- a/sourcecode/scoring/mf_multi_group_scorer.py
+++ b/sourcecode/scoring/mf_multi_group_scorer.py
@@ -1,0 +1,54 @@
+from . import constants as c
+from .mf_base_scorer import coalesce_columns
+from .mf_group_scorer import MFGroupScorer
+
+import pandas as pd
+
+
+def coalesce_multi_group_model_scored_notes(scoredNotes: pd.DataFrame) -> pd.DataFrame:
+  """Coalesce all multi group modeling columns across note scoring.
+
+  Since each Scorer must have distinct output columns, we use coalescing to run
+  multiple instances of MFGroupScorer objects and then condense the results into
+  a single set of columns.  This approach works because each note will be scored
+  by at most one MFGroupScorer instance.
+  """
+  for col in [
+    c.multiGroupNoteInterceptKey,
+    c.multiGroupNoteFactor1Key,
+    c.multiGroupRatingStatusKey,
+    c.modelingMultiGroupKey,
+    c.multiGroupInternalActiveRulesKey,
+    c.multiGroupNumFinalRoundRatingsKey,
+  ]:
+    scoredNotes = coalesce_columns(scoredNotes, col)
+
+  return scoredNotes
+
+
+def coalesce_multi_group_model_helpfulness_scores(helpfulnessScores: pd.DataFrame) -> pd.DataFrame:
+  """Coalesce all group modeling columns across user scoring.
+
+  Since each Scorer must have distinct output columns, we use coalescing to run
+  multiple instances of MFGroupScorer objects and then condense the results into
+  a single set of columns.  This approach works because each note will be scored
+  by at most one MFGroupScorer instance.
+  """
+  for col in [c.multiGroupRaterInterceptKey, c.multiGroupRaterFactor1Key, c.modelingMultiGroupKey]:
+    helpfulnessScores = coalesce_columns(helpfulnessScores, col)
+  return helpfulnessScores
+
+
+class MFMultiGroupScorer(MFGroupScorer):
+  def _init_column_names(self):
+    self._groupNoteInterceptKey = f"{c.multiGroupNoteInterceptKey}_{self._groupId}"
+    self._groupNoteFactor1Key = f"{c.multiGroupNoteFactor1Key}_{self._groupId}"
+    self._groupRatingStatusKey = f"{c.multiGroupRatingStatusKey}_{self._groupId}"
+    self._groupInternalActiveRulesKey = f"{c.multiGroupInternalActiveRulesKey}_{self._groupId}"
+    self._groupNumFinalRoundRatingsKey = f"{c.multiGroupNumFinalRoundRatingsKey}_{self._groupId}"
+    self._groupRaterInterceptKey = f"{c.multiGroupRaterInterceptKey}_{self._groupId}"
+    self._groupRaterFactor1Key = f"{c.multiGroupRaterFactor1Key}_{self._groupId}"
+    self._modelingGroupKey = f"{c.modelingMultiGroupKey}_{self._groupId}"
+
+  def get_name(self):
+    return f"MFMultiGroupScorer_{self._groupId}"

--- a/sourcecode/scoring/process_data.py
+++ b/sourcecode/scoring/process_data.py
@@ -188,19 +188,36 @@ def read_from_tsv(
   if noteStatusHistoryPath is None:
     noteStatusHistory = None
   else:
-    noteStatusHistory = tsv_reader(
-      noteStatusHistoryPath,
-      c.noteStatusHistoryTSVTypeMapping,
-      c.noteStatusHistoryTSVColumns,
-      header=headers,
-      convertNAToNone=False,
-    )
-    assert len(noteStatusHistory.columns.values) == len(c.noteStatusHistoryTSVColumns) and all(
-      noteStatusHistory.columns == c.noteStatusHistoryTSVColumns
-    ), (
-      f"noteStatusHistory columns don't match: \n{[col for col in noteStatusHistory.columns if not col in c.noteStatusHistoryTSVColumns]} are extra columns, "
-      + f"\n{[col for col in c.noteStatusHistoryTSVColumns if not col in noteStatusHistory.columns]} are missing."
-    )
+    # TODO(jiansongc): clean up after new column is in production.
+    try:
+      noteStatusHistory = tsv_reader(
+        noteStatusHistoryPath,
+        c.noteStatusHistoryTSVTypeMapping,
+        c.noteStatusHistoryTSVColumns,
+        header=headers,
+        convertNAToNone=False,
+      )
+      assert len(noteStatusHistory.columns.values) == len(c.noteStatusHistoryTSVColumns) and all(
+        noteStatusHistory.columns == c.noteStatusHistoryTSVColumns
+      ), (
+        f"noteStatusHistory columns don't match: \n{[col for col in noteStatusHistory.columns if not col in c.noteStatusHistoryTSVColumns]} are extra columns, "
+        + f"\n{[col for col in c.noteStatusHistoryTSVColumns if not col in noteStatusHistory.columns]} are missing."
+      )
+    except ValueError:
+      noteStatusHistory = tsv_reader(
+        noteStatusHistoryPath,
+        c.noteStatusHistoryTSVTypeMappingOld,
+        c.noteStatusHistoryTSVColumnsOld,
+        header=headers,
+        convertNAToNone=False,
+      )
+      noteStatusHistory[c.timestampMillisOfNmrDueToMinStableCrhTimeKey] = np.nan
+      assert len(noteStatusHistory.columns.values) == len(c.noteStatusHistoryTSVColumns) and all(
+        noteStatusHistory.columns == c.noteStatusHistoryTSVColumns
+      ), (
+        f"noteStatusHistory columns don't match: \n{[col for col in noteStatusHistory.columns if not col in c.noteStatusHistoryTSVColumns]} are extra columns, "
+        + f"\n{[col for col in c.noteStatusHistoryTSVColumns if not col in noteStatusHistory.columns]} are missing."
+      )
 
   if userEnrollmentPath is None:
     userEnrollment = None


### PR DESCRIPTION
-Add multi-group models (train multiple modeling groups together in one model)
-Memory-saving type improvements (e.g. use category instead of double for deprecated fields)
-Adjust flip-rate alert thresholds to be more appropriate given that we only rescore the subset of notes that trigger a rescoring rule now
-Add code to support NMRing notes when they haven't yet hit the CRH criteria for a minimum amount of time (currently disabled in prod by flag)

As usual, code is written by the multiple people on the team, not just me.