### PR TITLE
Updates to note selection for topic models

### DIFF
--- a/sourcecode/scoring/runner.py
+++ b/sourcecode/scoring/runner.py
@@ -2,7 +2,6 @@ import argparse
 import logging
 import os
 import sys
-from typing import Optional
 
 from . import constants as c
 from .enums import scorers_from_csv
@@ -213,7 +212,7 @@ def _run_scorer(
     previousScoredNotes = None
     previousAuxiliaryNoteInfo = None
 
-  # Sample ratings to decrease runtime  
+  # Sample ratings to decrease runtime
   if args.sample_ratings:
     origSize = len(ratings)
     ratings = ratings.sample(frac=args.sample_ratings)


### PR DESCRIPTION
This change guarantees post topics are assigned based on all notes associated with the post, and includes support for overriding assigned labels based on the confidence of the learned model.