### PR TITLE
Improve Python version compatibility and loosen flip rate limits

### DIFF
--- a/sourcecode/scoring/constants.py
+++ b/sourcecode/scoring/constants.py
@@ -43,13 +43,13 @@ tagPercentileForNormalization = 40
 intervalHalfWidth = 0.3
 
 # Max flip rates
-prescoringAllUnlockedNotesMaxCrhChurn = 0.2
-prescoringAllNotesCreatedThreeToThirteenDaysAgoMaxChurn = 0.09
-finalUnlockedNotesWithNoNewRatingsMaxCrhChurn = 0.075
-finalNotesWithNewRatingsMaxNewCrhChurn = 0.80
-finalNotesWithNewRatingsMaxOldCrhChurn = 0.25
-finalNotesThatJustFlippedStatusMaxCrhChurn = 1e8
-finalNotesThatFlippedRecentlyMaxCrhChurn = 1e8
+prescoringAllUnlockedNotesMaxCrhChurn = 0.3
+prescoringAllNotesCreatedThreeToThirteenDaysAgoMaxChurn = 0.15
+finalUnlockedNotesWithNoNewRatingsMaxCrhChurn = 0.12
+finalNotesWithNewRatingsMaxNewCrhChurn = 1.2
+finalNotesWithNewRatingsMaxOldCrhChurn = 0.4
+finalNotesThatJustFlippedStatusMaxCrhChurn = 1e7
+finalNotesThatFlippedRecentlyMaxCrhChurn = 1e7
 # TODO(jiansongc): adjust these 2 below
 finalNotesNmrDueToMinStableCrhTimeMaxOldCrhChurn = 1.0
 finalNotesNmrDueToMinStableCrhTimeMaxNewCrhChurn = 1.0
@@ -78,7 +78,7 @@ defaultIndexKey = "index"
 
 # Scoring Groups
 coreGroups: Set[int] = {1, 2, 3, 6, 8, 9, 10, 11, 13, 14, 19, 21, 25}
-expansionGroups: Set[int] = {0, 4, 5, 7, 12, 15, 16, 18, 20, 22, 23, 26, 27, 28, 29}
+expansionGroups: Set[int] = {0, 4, 5, 7, 12, 15, 16, 18, 20, 22, 23, 26, 27, 28, 29, 33}
 expansionPlusGroups: Set[int] = {17, 24, 30, 31, 32}
 
 # TSV Values

--- a/sourcecode/scoring/topic_model.py
+++ b/sourcecode/scoring/topic_model.py
@@ -61,12 +61,12 @@ class TopicModel(object):
     regex_patterns = {}
     for topic, patterns in self._seedTerms.items():
       # require whitespace or start-of-string at the beginning of each match
-      patterns = [f"(?im)(\s|^){pattern}" for pattern in patterns]
+      patterns = [f"(\s|^){pattern}" for pattern in patterns]
       group_name = f"{topic.name}"
       regex_patterns[group_name] = f"(?P<{group_name}>{'|'.join(patterns)})"
 
     combined_regex = "|".join(regex_patterns.values())
-    return re.compile(combined_regex, re.IGNORECASE)
+    return re.compile(combined_regex, re.IGNORECASE | re.MULTILINE)
 
   def _make_seed_labels(self, texts: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     """Produce a label vector based on seed terms.


### PR DESCRIPTION
Previously, we used a regex that only worked in Python<=3.10. Now it is updated to work again in newer versions of Python.