### PR TITLE
Add referenced posts (quoted or replied-to) to context in note writer

### DIFF
--- a/template-api-note-writer/src/cnapi/get_api_eligible_posts.py
+++ b/template-api-note-writer/src/cnapi/get_api_eligible_posts.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from typing import Dict, List
 
-from src.cnapi.xurl_util import run_xurl
+from cnapi.xurl_util import run_xurl
 
-from src.data_models import Media, Post, PostWithContext
+from data_models import Media, Post, PostWithContext
 
 
 def _fetch_posts_eligible_for_notes(
@@ -113,7 +113,7 @@ def _parse_posts_eligible_response(resp: Dict) -> List[PostWithContext]:
 
 def get_posts_eligible_for_notes(
     max_results: int = 2, test_mode: bool = True
-) -> List[Post]:
+) -> List[PostWithContext]:
     """
     Get posts eligible for notes by calling the Community Notes API.
     For more details, see: https://docs.x.com/x-api/community-notes/introduction
@@ -124,9 +124,3 @@ def get_posts_eligible_for_notes(
     return _parse_posts_eligible_response(
         _fetch_posts_eligible_for_notes(max_results, test_mode)
     )
-
-
-if __name__ == "__main__":
-    # Example: $ uv run -m src.cnapi.get_api_eligible_posts
-    eligible_posts = get_posts_eligible_for_notes(max_results=10)
-    print("\n\n".join([str(post) for post in eligible_posts]))

--- a/template-api-note-writer/src/cnapi/get_api_eligible_posts.py
+++ b/template-api-note-writer/src/cnapi/get_api_eligible_posts.py
@@ -101,12 +101,12 @@ def _parse_posts_eligible_response(resp: Dict) -> List[PostWithContext]:
                 else:
                     raise ValueError(f"Unknown referenced tweet type: {ref['type']} (expected 'quoted' or 'replied_to')")
 
-        postWithContext = PostWithContext(
+        post_with_context = PostWithContext(
             post=post,
             quoted_post=quoted_post,
             in_reply_to_post=in_reply_to_post,
         )
-        posts.append(postWithContext)
+        posts.append(post_with_context)
 
     return posts
 

--- a/template-api-note-writer/src/data_models.py
+++ b/template-api-note-writer/src/data_models.py
@@ -44,6 +44,13 @@ class Post(BaseModel):
     media: List[Media]
 
 
+class PostWithContext(BaseModel):
+    post: Post
+    quoted_post: Optional[Post] = None
+    in_reply_to_post: Optional[Post] = None
+
+
+
 class NoteResult(BaseModel):
     note: Optional[ProposedMisleadingNote] = None
     refusal: Optional[str] = None

--- a/template-api-note-writer/src/data_models.py
+++ b/template-api-note-writer/src/data_models.py
@@ -50,10 +50,9 @@ class PostWithContext(BaseModel):
     in_reply_to_post: Optional[Post] = None
 
 
-
 class NoteResult(BaseModel):
     note: Optional[ProposedMisleadingNote] = None
     refusal: Optional[str] = None
     error: Optional[str] = None
-    post: Optional[Post] = None
-    images_summary: Optional[str] = None
+    post: Optional[PostWithContext] = None
+    context_description: Optional[str] = None

--- a/template-api-note-writer/src/note_writer/llm_util.py
+++ b/template-api-note-writer/src/note_writer/llm_util.py
@@ -19,7 +19,7 @@ def _make_request(payload: dict):
     return response.json()["choices"][0]["message"]["content"]
 
 
-def get_grok_response(prompt: str, temperature: float = 0.8, model: str = "grok-4-latest"):
+def get_grok_response(prompt: str, temperature: float = 0.8, model: str = "grok-3-latest"):
     payload = {
         "messages": [
             {
@@ -34,7 +34,7 @@ def get_grok_response(prompt: str, temperature: float = 0.8, model: str = "grok-
     return _make_request(payload)
 
 
-def grok_describe_image(image_url: str, temperature: float = 0.01):
+def grok_describe_image(image_url: str, temperature: float = 0.01, model: str = "grok-2-vision-latest"):
     """
     Currently just describe image on its own. There are many possible
     improvements to consider making, e.g. passing in the post text or
@@ -59,19 +59,19 @@ def grok_describe_image(image_url: str, temperature: float = 0.01):
                 ],
             },
         ],
-        "model": "grok-2-vision-latest",
+        "model": model,
         "temperature": temperature,
     }
     return _make_request(payload)
 
 
-def get_grok_live_search_response(prompt: str, temperature: float = 0.8):
+def get_grok_live_search_response(prompt: str, temperature: float = 0.8, model= "grok-3-latest"):
     payload = {
         "messages": [{"role": "user", "content": prompt}],
         "search_parameters": {
             "mode": "on",
         },
-        "model": "grok-3-latest",
+        "model": model,
         "temperature": temperature,
     }
     return _make_request(payload)

--- a/template-api-note-writer/src/note_writer/llm_util.py
+++ b/template-api-note-writer/src/note_writer/llm_util.py
@@ -19,7 +19,7 @@ def _make_request(payload: dict):
     return response.json()["choices"][0]["message"]["content"]
 
 
-def get_grok_response(prompt: str, temperature: float = 0.8):
+def get_grok_response(prompt: str, temperature: float = 0.8, model: str = "grok-4-latest"):
     payload = {
         "messages": [
             {
@@ -28,7 +28,7 @@ def get_grok_response(prompt: str, temperature: float = 0.8):
             },
             {"role": "user", "content": prompt},
         ],
-        "model": "grok-3-latest",
+        "model": model,
         "temperature": temperature,
     }
     return _make_request(payload)

--- a/template-api-note-writer/src/note_writer/misleading_tags.py
+++ b/template-api-note-writer/src/note_writer/misleading_tags.py
@@ -6,10 +6,10 @@ from note_writer.llm_util import get_grok_response
 
 
 def get_misleading_tags(
-    post: Post, images_summary: str, note_text: str, retries: int = 3
+    post_with_context_description: str, note_text: str, retries: int = 3
 ) -> List[MisleadingTag]:
     misleading_why_tags_prompt = _get_prompt_for_misleading_why_tags(
-        post, images_summary, note_text
+        post_with_context_description, note_text
     )
     while retries > 0:
         try:
@@ -23,15 +23,7 @@ def get_misleading_tags(
     raise Exception("Failed to get misleading tags for note.")
 
 
-def _get_prompt_for_misleading_why_tags(
-    post: Post, images_summary: str = "", note: str = ""
-):
-    images_summary_prompt = f"""```
-    Summary of images in the post:
-    ```
-    {images_summary}
-    ```"""
-
+def _get_prompt_for_misleading_why_tags(post_with_context_description: str, note: str):
     return f"""Below will be a post on X, and a proposed community note that \
 adds additional context to the potentially misleading post. \
 Your task will be to identify which of the following tags apply to the post and note. \
@@ -51,22 +43,16 @@ Example valid JSON response:
 }}
 
 OTHER = 0
-  FACTUAL_ERROR = 1
-  MANIPULATED_MEDIA = 2
-  OUTDATED_INFORMATION = 3
-  MISSING_IMPORTANT_CONTEXT = 4
-  DISPUTED_CLAIM_AS_FACT = 5
-  MISINTERPRETED_SATIRE = 6
+FACTUAL_ERROR = 1
+MANIPULATED_MEDIA = 2
+OUTDATED_INFORMATION = 3
+MISSING_IMPORTANT_CONTEXT = 4
+DISPUTED_CLAIM_AS_FACT = 5
+MISINTERPRETED_SATIRE = 6
 
 The post and note are as follows:
 
-```
-Post text:
-```
-{post.text}
-```
-
-{images_summary_prompt}
+{post_with_context_description}
 
 ```
 Proposed community note:

--- a/template-api-note-writer/src/note_writer/write_note.py
+++ b/template-api-note-writer/src/note_writer/write_note.py
@@ -1,4 +1,4 @@
-from data_models import NoteResult, Post, ProposedMisleadingNote
+from data_models import NoteResult, Post, PostWithContext, ProposedMisleadingNote
 from note_writer.llm_util import (
     get_grok_live_search_response,
     get_grok_response,
@@ -7,7 +7,7 @@ from note_writer.llm_util import (
 from note_writer.misleading_tags import get_misleading_tags
 
 
-def _get_prompt_for_note_writing(post: Post, images_summary: str, search_results: str):
+def _get_prompt_for_note_writing(post_with_context_description: str, search_results: str):
     return f"""Below will be a post on X, and live search results from the web. \
 If the post is misleading and needs a community note, \
 then your response should be the proposed community note itself. \
@@ -38,16 +38,7 @@ write an ironclad community note, then your response should be \
 
 If you are writing a note, don't preface it with anything like "Community Note:". Just write the note.
 
-    ```
-    Post text:
-    ```
-    {post.text}
-    ```
-
-    Summary of images in the post:
-    ```
-    {images_summary}
-    ```
+    {post_with_context_description}
 
     Live search results:
     ```
@@ -63,65 +54,115 @@ saying that the prediction is uncertain or likely to be wrong. \
     """
 
 
-def _get_prompt_for_live_search(post: Post, images_summary: str = ""):
+def _get_post_with_context_description_for_prompt(post_with_context: PostWithContext) -> str:
+    description = f"""Post text:
+```
+{post_with_context.post.text}
+```
+"""
+    images_summary = _summarize_images_for_post(post_with_context.post)
+    if images_summary is not None and len(images_summary) > 0:
+        description += f"""Summary of images in the post:
+```
+{images_summary}
+```
+"""
+    if post_with_context.quoted_post:
+        description += f"""The post of interest had quoted (referenced) another post. Here is the quoted post's text:
+```
+{post_with_context.quoted_post.text}
+```
+"""
+        quoted_images_summary = _summarize_images_for_post(post_with_context.quoted_post)
+        if quoted_images_summary is not None and len(quoted_images_summary) > 0:
+            description += f"""Summary of images in the quoted post:
+```
+{quoted_images_summary}
+```
+"""
+    
+    if post_with_context.in_reply_to_post:
+        description += f"""The post of interest was a reply to another post. Here is the replied-to post's text:
+```
+{post_with_context.in_reply_to_post.text}
+```
+"""
+        replied_to_images_summary = _summarize_images_for_post(post_with_context.in_reply_to_post)
+        if replied_to_images_summary is not None and len(replied_to_images_summary) > 0:
+            description += f"""Summary of images in the replied-to post:
+```
+{replied_to_images_summary}
+```
+"""
+
+    return description
+
+
+def _get_prompt_for_live_search(post_with_context_description: str) -> str:
     return f"""Below will be a post on X. Do research on the post to determine if the post is potentially misleading. \
 Your response MUST include URLs/links directly in the text, next to the claim it supports. Don't include any sort \
 of wasted characters e.g. [Source] when listing a URL. Just state the URL directly in the text. \
 
-    Post text:
-    ```
-    {post.text}
-    ```
-
-    Summary of images in the post:
-    ```
-    {images_summary}
-    ```
+    {post_with_context_description}
     """
 
-
-def _summarize_images(post: Post) -> str:
+def _summarize_images_for_post(post: Post) -> str:
     """
     Summarize images, if they exist. Abort if video or other unsupported media type.
     """
     images_summary = ""
     for i, media in enumerate(post.media):
-        if media.media_type == "photo":
-            image_description = grok_describe_image(media.url)
-            images_summary += f"Image {i}: {image_description}\n\n"
-        elif media.media_type == "video":
-            raise ValueError("Video not supported yet")
-        else:
-            raise ValueError(f"Unsupported media type: {media.media_type}")
+        assert media.media_type == "photo" # remove assert when video support is added
+        image_description = grok_describe_image(media.url)
+        images_summary += f"Image {i}: {image_description}\n"
     return images_summary
 
 
+def _check_for_unsupported_media(post: Post) -> bool:
+    """Check if the post contains unsupported media types."""
+    for media in post.media:
+        if media.media_type not in ["photo"]:
+            return True
+
+
+def _check_for_unsupported_media_in_post_with_context(post_with_context: PostWithContext) -> None:
+    """Check if the post or any referenced posts contain unsupported media types."""
+    if _check_for_unsupported_media(post_with_context.post):
+        return True
+    if post_with_context.quoted_post and _check_for_unsupported_media(post_with_context.quoted_post):
+        return True
+    if post_with_context.in_reply_to_post and _check_for_unsupported_media(post_with_context.in_reply_to_post):
+        return True
+    return False
+
+
 def research_post_and_write_note(
-    post: Post,
+    post_with_context: PostWithContext,
 ) -> NoteResult:
-    try:
-        images_summary = _summarize_images(post)
-    except ValueError as e:
-        return NoteResult(post=post, error=str(e))
+    if _check_for_unsupported_media_in_post_with_context(post_with_context):
+        return NoteResult(post=post_with_context, error="Unsupported media type (e.g. video) found in post or in referenced post.")
+    
+    post_with_context_description = _get_post_with_context_description_for_prompt(post_with_context)
 
-    search_prompt = _get_prompt_for_live_search(post, images_summary)
+    search_prompt = _get_prompt_for_live_search(post_with_context_description)
     search_results = get_grok_live_search_response(search_prompt)
-    note_prompt = _get_prompt_for_note_writing(post, images_summary, search_results)
 
+    note_prompt = _get_prompt_for_note_writing(post_with_context_description, search_results)
     note_or_refusal_str = get_grok_response(note_prompt)
 
     if ("NO NOTE NEEDED" in note_or_refusal_str) or (
         "NOT ENOUGH EVIDENCE TO WRITE A GOOD COMMUNITY NOTE" in note_or_refusal_str
     ):
-        return NoteResult(post=post, refusal=note_or_refusal_str)
+        return NoteResult(post=post_with_context, refusal=note_or_refusal_str, context_description=post_with_context_description)
 
-    misleading_tags = get_misleading_tags(post, images_summary, note_or_refusal_str)
+    misleading_tags = get_misleading_tags(post_with_context_description, note_or_refusal_str)
 
     return NoteResult(
-        post=post,
+        post=post_with_context,
         note=ProposedMisleadingNote(
-            post_id=post.post_id,
+            post_id=post_with_context.post.post_id,
             note_text=note_or_refusal_str,
             misleading_tags=misleading_tags,
         ),
+        context_description=post_with_context_description,
     )

--- a/template-api-note-writer/uv.lock
+++ b/template-api-note-writer/uv.lock
@@ -65,27 +65,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cnapi"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "dotenv" },
-    { name = "pre-commit" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "dotenv", specifier = ">=0.9.9" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "pydantic", specifier = ">=2.11.7" },
-    { name = "requests", specifier = ">=2.32.3" },
-    { name = "ruff", specifier = ">=0.12.0" },
-]
-
-[[package]]
 name = "distlib"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
@@ -296,6 +275,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/ef/b960ab4818f90ff59e571d03c3f992828d4683561095e80f9ef31f3d58b7/ruff-0.12.0-py3-none-win32.whl", hash = "sha256:7162a4c816f8d1555eb195c46ae0bd819834d2a3f18f98cc63819a7b46f474fb", size = 10525289 },
     { url = "https://files.pythonhosted.org/packages/34/93/8b16034d493ef958a500f17cda3496c63a537ce9d5a6479feec9558f1695/ruff-0.12.0-py3-none-win_amd64.whl", hash = "sha256:d00b7a157b8fb6d3827b49d3324da34a1e3f93492c1f97b08e222ad7e9b291e0", size = 11598311 },
     { url = "https://files.pythonhosted.org/packages/d0/33/4d3e79e4a84533d6cd526bfb42c020a23256ae5e4265d858bd1287831f7d/ruff-0.12.0-py3-none-win_arm64.whl", hash = "sha256:8cd24580405ad8c1cc64d61725bca091d6b6da7eb3d36f72cc605467069d7e8b", size = 10724946 },
+]
+
+[[package]]
+name = "template-api-note-writer"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "dotenv" },
+    { name = "pre-commit" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "requests", specifier = ">=2.32.3" },
+    { name = "ruff", specifier = ">=0.12.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
-Parse the CN API response to retrieve any quoted or replied-to posts
-Add them to context (including a summary of any images) when writing a community note or live-searching