### PR TITLE
Fix: Prevent AssertionError by sorting ratings in serial mode

### DIFF
--- a/scoring/src/scoring/run_scoring.py
+++ b/scoring/src/scoring/run_scoring.py
@@ -489,6 +489,11 @@ def _run_scorers(
         shm.unlink()
       logger.info("All shared memory segments cleaned up")
   else:
+    # The serial path needs explicit sorting to satisfy an assertion in mf_base_scorer.
+    # In parallel mode, this is handled implicitly during shared memory setup.
+    scoringArgs.ratings = scoringArgs.ratings.sort_values(
+      [c.highVolumeRaterKey, c.correlatedRaterKey], ascending=True
+    )
     modelResultsAndTimes = [
       _run_scorer_in_series(
         scorer=scorer,


### PR DESCRIPTION
Fixes #369

This PR fixes an `AssertionError` that occurred when running the scorer in serial mode (without the `--parallel` flag).

The `ratings` DataFrame was not being sorted in the serial execution path, leading to the assertion failure in `mf_base_scorer.py`. I've added the sorting step to the serial path to align it with the parallel path's behavior.