### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Redirects
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           # Upload entire repository
           path: './documentation/_redirects/'
       - name: Deploy Redirects
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/configure-pages` | [`v3`](https://github.com/actions/configure-pages/releases/tag/v3) | [`v5`](https://github.com/actions/configure-pages/releases/tag/v5) | [Release](https://github.com/actions/configure-pages/releases/tag/v5) | main.yml |
| `actions/deploy-pages` | [`v1`](https://github.com/actions/deploy-pages/releases/tag/v1) | [`v4`](https://github.com/actions/deploy-pages/releases/tag/v4) | [Release](https://github.com/actions/deploy-pages/releases/tag/v4) | main.yml |
| `actions/upload-pages-artifact` | [`v1`](https://github.com/actions/upload-pages-artifact/releases/tag/v1) | [`v4`](https://github.com/actions/upload-pages-artifact/releases/tag/v4) | [Release](https://github.com/actions/upload-pages-artifact/releases/tag/v4) | main.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
