### PR TITLE
Fix ineffective .astype() calls in note_ratings.py

### DIFF
--- a/scoring/src/scoring/note_ratings.py
+++ b/scoring/src/scoring/note_ratings.py
@@ -390,7 +390,10 @@ def compute_note_stats(ratings: pd.DataFrame, noteStatusHistory: pd.DataFrame) -
 
 
 def get_note_counts_by_rater_sign(raterModelOutput, ratings):
-  raterModelOutput[c.raterParticipantIdKey].astype(ratings[c.raterParticipantIdKey].dtype)
+  raterModelOutput = raterModelOutput.copy()
+  raterModelOutput[c.raterParticipantIdKey] = raterModelOutput[c.raterParticipantIdKey].astype(
+    ratings[c.raterParticipantIdKey].dtype
+  )
 
   if c.helpfulNumKey not in ratings.columns:
     ratings[c.helpfulNumKey] = 0.5
@@ -522,7 +525,10 @@ def get_note_counts_by_rater_sign(raterModelOutput, ratings):
 
 
 def get_population_sampled_counts_by_rater_sign(raterModelOutput, ratings):
-  raterModelOutput[c.raterParticipantIdKey].astype(ratings[c.raterParticipantIdKey].dtype)
+  raterModelOutput = raterModelOutput.copy()
+  raterModelOutput[c.raterParticipantIdKey] = raterModelOutput[c.raterParticipantIdKey].astype(
+    ratings[c.raterParticipantIdKey].dtype
+  )
 
   ratingsToUse = pd.DataFrame(
     ratings[[c.noteIdKey, c.raterParticipantIdKey, c.ratingSourceBucketedKey]]


### PR DESCRIPTION
## Summary

Fixed two instances where `.astype()` calls had no effect because the return value was discarded.

## Problem

In `scoring/src/scoring/note_ratings.py`, the following pattern appeared in two functions:

```python
raterModelOutput[c.raterParticipantIdKey].astype(ratings[c.raterParticipantIdKey].dtype)
```

**Issue:** In pandas, `.astype()` returns a **new** Series with the converted dtype - it does **not** modify the original Series in place. Since the return value was not being assigned, this code was effectively a no-op.

**Affected functions:**
- `get_note_counts_by_rater_sign()` (line 393)
- `get_population_sampled_counts_by_rater_sign()` (line 525)

## Impact

This bug could cause type mismatch issues during subsequent merge operations if `raterParticipantIdKey` columns have different dtypes between the `raterModelOutput` and `ratings` DataFrames. The intent of the original code was clearly to ensure type compatibility before merging.

## Fix

```python
raterModelOutput = raterModelOutput.copy()
raterModelOutput[c.raterParticipantIdKey] = raterModelOutput[c.raterParticipantIdKey].astype(
  ratings[c.raterParticipantIdKey].dtype
)
```

The fix:
1. Creates a defensive copy to avoid mutating the input DataFrame
2. Properly assigns the result of `.astype()` back to the column

## Testing

This is a straightforward bug fix that makes the existing code work as originally intended. The logic remains the same - only now the type conversion actually takes effect.