### PR TITLE
Set max stabilization time to 60mins

### DIFF
--- a/scoring/src/scoring/constants.py
+++ b/scoring/src/scoring/constants.py
@@ -81,8 +81,8 @@ correlatedRaterKey = "correlatedRater"
 # Scoring Groups
 coreGroups: Set[int] = {1, 2, 3, 6, 8, 9, 10, 11, 13, 14, 19, 21, 25}
 coverageGroups: Set[int] = {1, 2, 3, 6, 8, 9, 10, 11, 13, 14, 19, 25}
-expansionGroups: Set[int] = {0, 4, 5, 7, 12, 15, 16, 18, 20, 22, 23, 26, 27, 28, 29, 33}
-expansionPlusGroups: Set[int] = {17, 24, 30, 31, 32}
+expansionGroups: Set[int] = {0, 4, 5, 7, 12, 15, 16, 20, 22, 23, 26, 27, 28, 29, 33}
+expansionPlusGroups: Set[int] = {17, 18, 24, 30, 31, 32}
 
 # Bins for Gaussian Scorer
 quantileRange = np.array(

--- a/scoring/src/scoring/scoring_rules.py
+++ b/scoring/src/scoring/scoring_rules.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from collections import namedtuple
 from enum import Enum
-import hashlib
 import logging
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
@@ -777,10 +776,8 @@ class NmrDueToMinStableCrhTime(ScoringRule):
     ruleID: RuleID,
     dependencies: Set[RuleID],
     requiredStableCrhMinutesThreshold: int = 30,
+    maxStableCrhMinutesThreshold: int = 60,
     maxNyhMinutesThreshold: int = 360,
-    # maxStableCrhMinutesThreshold: int = 150, # TODO: set this after A/B test resolved
-    maxStableCrhMinutesThresholdABHighEvenBucket=120,  # TODO: delete after A/B test resolved
-    maxStableCrhMinutesThresholdABLowOddBucket=60,  # TODO: delete after A/B test resolved
   ):
     """
     Args:
@@ -793,12 +790,8 @@ class NmrDueToMinStableCrhTime(ScoringRule):
     """
     super().__init__(ruleID, dependencies)
     self.requiredStableCrhMinutesThreshold = requiredStableCrhMinutesThreshold
+    self.maxStableCrhMinutesThreshold = maxStableCrhMinutesThreshold
     self.maxNyhMinutesThreshold = maxNyhMinutesThreshold
-
-    # TODO: started A/B test for max stable CRH minutes Feb 13, 2026. Once analyzed, revert to fixed value.
-    # self.maxStableCrhMinutesThreshold = maxStableCrhMinutesThreshold
-    self.maxStableCrhMinutesThresholdABHighEvenBucket = maxStableCrhMinutesThresholdABHighEvenBucket
-    self.maxStableCrhMinutesThresholdABLowOddBucket = maxStableCrhMinutesThresholdABLowOddBucket
 
   def score_notes(
     self, noteStats: pd.DataFrame, currentLabels: pd.DataFrame, statusColumn: str
@@ -913,31 +906,12 @@ class NmrDueToMinStableCrhTime(ScoringRule):
     notesAlreadyInStabilization = (
       noteStatusUpdates[c.timestampMillisOfNmrDueToMinStableCrhTimeKey] > 0
     )
-
-    # Set max stabilization period based on A/B test. TODO: cleanup when A/B test cleaned up.
-    # Bucketing uses MD5 hash of noteId for unbiased 50/50 split:
-    #   - Bucket 0 (first hex char is even: 0,2,4,6,8,A,C,E): high threshold (120 min)
-    #   - Bucket 1 (first hex char is odd: 1,3,5,7,9,B,D,F): low threshold (60 min)
-    maxStableCrhMinutesThresholdKey = "maxStableCrhMinutesThreshold"
-
-    def _get_ab_test_bucket(noteId: int) -> int:
-      """Get A/B test bucket (0 or 1) using MD5 hash of noteId."""
-      return int(hashlib.md5(str(int(noteId)).encode()).hexdigest()[0], 16) % 2
-
-    noteStatusUpdates[maxStableCrhMinutesThresholdKey] = noteStatusUpdates[c.noteIdKey].apply(
-      lambda noteId: self.maxStableCrhMinutesThresholdABHighEvenBucket
-      if _get_ab_test_bucket(noteId) == 0
-      else self.maxStableCrhMinutesThresholdABLowOddBucket
-    )
-
     # (1)-(C)-(a): Exit stabilization period to CRH if the note has been in the period for
     # longer than maxStableCrhMinutesThreshold and the note is currently scored CRH.
     inStabilizationLongerThanCrhMax = (
       c.epochMillis - noteStatusUpdates[c.timestampMillisOfNmrDueToMinStableCrhTimeKey]
-      > noteStatusUpdates[maxStableCrhMinutesThresholdKey] * 60 * 1000
+      > self.maxStableCrhMinutesThreshold * 60 * 1000
     )
-    # Drop temporary A/B test column before merge to avoid type conversion issues
-    noteStatusUpdates = noteStatusUpdates.drop(columns=[maxStableCrhMinutesThresholdKey])
 
     noteStatusUpdates.loc[
       notesGoingCrh & notesAlreadyInStabilization & inStabilizationLongerThanCrhMax,


### PR DESCRIPTION
Resolve an A/B test on max stabilization time. Set to 60mins instead of 120mins, which will reduce time to CRH significantly.