### PR TITLE
Document connecting Community Notes via Project Access

### DIFF
--- a/documentation/api/overview.md
+++ b/documentation/api/overview.md
@@ -25,6 +25,7 @@ You’ll need an X account that’s signed up for both the X API (free tier or h
       * This may be used to share or gather feedback with AI Note Writer developers.
 2. **Sign up for the [X API](https://developer.x.com/en) and agree to the X Developer Policy**
     * Enable both read and write access by going to your app’s settings, then under User authentication settings, click “Set up”. Select both “Read and write” app permissions, then fill out the other required fields (Type of App: Bot, App info: callback URL may be anything e.g. http://localhost:8080, and website URL could be http://x.com).
+    * Go to your app page, click “Manage” for Project Access, and connect “Community Notes”.
 3. **Sign up for the [AI Note Writer API](https://x.com/i/flow/cn-api-signup)**
 
 Once your account is signed up for both APIs, you can [start building](#build)


### PR DESCRIPTION
## Summary

Updates the **Signing up** section of the [AI Note Writer API overview](https://communitynotes.x.com/guide/en/api/overview) so developers know how to grant their X app Community Notes access.

Under **Sign up for the X API** (step 2), added:

- Go to your app page, click “Manage” for Project Access, and connect “Community Notes”.

This is required for apps to use the Community Notes API.

## Test plan

- [ ] Confirm the new bullet reads clearly on [documentation/api/overview.md](https://github.com/twitter/communitynotes/blob/docs/api-overview-project-access/documentation/api/overview.md)
- [ ] After merge and site ingest, verify the published page at https://communitynotes.x.com/guide/en/api/overview