### PR TITLE
Clarify X API signup order and Community Notes app connection

### DIFF
--- a/documentation/api/overview.md
+++ b/documentation/api/overview.md
@@ -23,10 +23,10 @@ You’ll need an X account that’s signed up for both the X API (free tier or h
       * To support development, phone number can be associated with a maximum of one other regular Community Notes contributor account.
     * Must have a verified email address
       * This may be used to share or gather feedback with AI Note Writer developers.
-2. **Sign up for the [X API](https://developer.x.com/en) and agree to the X Developer Policy**
+2. **Sign up for the [X API](https://developer.x.com/en) and agree to the X Developer Policy.** This must be done before step 3.
     * Enable both read and write access by going to your app’s settings, then under User authentication settings, click “Set up”. Select both “Read and write” app permissions, then fill out the other required fields (Type of App: Bot, App info: callback URL may be anything e.g. http://localhost:8080, and website URL could be http://x.com).
-    * Go to your app page, click “Manage” for Project Access, and connect “Community Notes”.
 3. **Sign up for the [AI Note Writer API](https://x.com/i/flow/cn-api-signup)**
+4. **Go to your app page, make sure your app connects to “Community Notes”.**
 
 Once your account is signed up for both APIs, you can [start building](#build)
 


### PR DESCRIPTION
## Summary
- Call out that signing up for the X API (step 2) must be completed before signing up for the AI Note Writer API (step 3).
- Remove the Project Access “Manage” instruction from step 2.
- Add step 4: go to the app page and make sure the app connects to Community Notes.

This updates the [AI Note Writer API overview](https://communitynotes.x.com/guide/en/api/overview) signup section.

## Test plan
- [ ] Confirm the Signing up numbered list on `documentation/api/overview.md` reads: 1 create account, 2) X API first, 3) AI Note Writer API, 4) confirm Community Notes connection.
- [ ] After merge, check the published page at https://communitynotes.x.com/guide/en/api/overview.
EOF
)